### PR TITLE
Improve dependencies in docker-compose, wait for postgres to init

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '3.6'
+version: "2.4"
 
 services:
-
   proxy:
     image: nginx:1.15.8-alpine
     container_name: nginx.cityvizor.cesko.digital
@@ -20,8 +19,10 @@ services:
     environment:
       DATABASE_ADDRESS: db.cityvizor.cesko.digital
     depends_on:
-      - postgres
-      - proxy
+      postgres:
+        condition: service_healthy
+      proxy:
+        condition: service_started
 
   cityvizor-server:
     image: cityvizor-server
@@ -32,9 +33,11 @@ services:
       NODE_ENV: local
     volumes:
       - ./data:/user/src/app/data
-    depends_on: 
-      - postgres
-      - proxy
+    depends_on:
+      postgres:
+        condition: service_healthy
+      proxy:
+        condition: service_started
 
   cityvizor-worker:
     image: cityvizor-server
@@ -45,26 +48,32 @@ services:
       NODE_ENV: local
     volumes:
       - ./data:/user/src/app/data
-    depends_on: 
-      - postgres
+    depends_on:
+      postgres:
+        condition: service_healthy
 
   cityvizor-client:
     image: cityvizor-client
-    build: ./client   
+    build: ./client
     container_name: client.cityvizor.cesko.digital
     environment:
-      NODE_ENV: local  
-    depends_on: 
-      - proxy  
-      
+      NODE_ENV: local
+    depends_on:
+      - proxy
+
   postgres:
     image: postgres:11.1
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     container_name: db.cityvizor.cesko.digital
     environment:
       POSTGRES_DB: cityvizor
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: pass
     volumes:
-      - ./database/oict_dump.sql:/docker-entrypoint-initdb.d/oict_dump.sql
+      - ./database/demo_dump.sql:/docker-entrypoint-initdb.d/demo_dump.sql
     ports:
       - 5432:5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,38 +1,27 @@
 version: '3.6'
-networks:
-  internal-net:
-    name: workbench_subnet
+
 services:
+
   proxy:
     image: nginx:1.15.8-alpine
-    depends_on:
-      - backend-kotlin
-      - cityvizor-server
-      - cityvizor-worker
     container_name: nginx.cityvizor.cesko.digital
     ports:
       - "4200:80"
     volumes:
-      - ./client/dist:/usr/share/nginx/html:ro
       - ./nginx:/etc/nginx:ro
     environment:
       NGINX_HOST: cityvizor.cesko.digital
       NGINX_PORT: 80
-    networks:
-      - internal-net
 
   backend-kotlin:
     image: backend-kotlin
     build: server-kotlin/.
-    expose:
-      - 8080
-    depends_on:
-      - postgres
     container_name: backend.cityvizor.cesko.digital
-    networks:
-      - internal-net
     environment:
       DATABASE_ADDRESS: db.cityvizor.cesko.digital
+    depends_on:
+      - postgres
+      - proxy
 
   cityvizor-server:
     image: cityvizor-server
@@ -45,31 +34,28 @@ services:
       - ./data:/user/src/app/data
     depends_on: 
       - postgres
-    networks:
-      - internal-net
+      - proxy
 
   cityvizor-worker:
     image: cityvizor-server
     build: ./server
-    environment:
-      NODE_ENV: local
     command: node dist/worker.js
     container_name: worker.cityvizor.cesko.digital
+    environment:
+      NODE_ENV: local
     volumes:
       - ./data:/user/src/app/data
     depends_on: 
       - postgres
-    networks:
-      - internal-net
 
   cityvizor-client:
     image: cityvizor-client
     build: ./client   
     container_name: client.cityvizor.cesko.digital
     environment:
-      NODE_ENV: local    
-    networks:
-      - internal-net
+      NODE_ENV: local  
+    depends_on: 
+      - proxy  
       
   postgres:
     image: postgres:11.1
@@ -80,7 +66,5 @@ services:
       POSTGRES_PASSWORD: pass
     volumes:
       - ./database/oict_dump.sql:/docker-entrypoint-initdb.d/oict_dump.sql
-    networks:
-      - internal-net
     ports:
       - 5432:5432

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,6 +3,9 @@ events {
 }
 
 http {
+
+  resolver 127.0.0.11 valid=30s;
+  
   server {
     listen 80;
     server_name cityvizor.cesko.digital;
@@ -10,20 +13,23 @@ http {
     index index.html;
 
     location  /api/v2/service/citysearch {
-      proxy_pass         http://backend.cityvizor.cesko.digital:8080;
+      set                $upstream_backend http://backend.cityvizor.cesko.digital:8080;
+      proxy_pass         $upstream_backend;
       proxy_redirect     off;
       proxy_set_header   Host $host;
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
     location  /api {
-      proxy_pass         http://server.cityvizor.cesko.digital:3000;
+      set                $upstream_server http://server.cityvizor.cesko.digital:3000;
+      proxy_pass         $upstream_server;
       proxy_redirect     off;
       proxy_set_header   Host $host;
     }
 
     location  / {
-      proxy_pass         http://client.cityvizor.cesko.digital:80;
+      set                $upstream_client http://client.cityvizor.cesko.digital:80;
+      proxy_pass         $upstream_client;
       proxy_redirect     off;
       proxy_set_header   Host $host;
     }


### PR DESCRIPTION
- services are now dependent on nginx, i.e. when service is started, nginx is also started
- services wait for postgres to report healthy, i.e. seed dump is loaded and database started