### PR TITLE
Fix upload size problem

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -12,6 +12,8 @@ http {
     root /usr/share/nginx/html;
     index index.html;
 
+    client_max_body_size 10M;
+
     location  /api/v2/service/citysearch {
       set                $upstream_backend http://backend.cityvizor.cesko.digital:8080;
       proxy_pass         $upstream_backend;


### PR DESCRIPTION
(cherry picked from commit 6d46cb53255a54e464bd770996af1c652f697475)

Hotfix from prod branch

When limit not set in nginx, it is 1MB. Some browsers in some environments (didnt find a pattern, probably proxy?) do not use gzip and breach this limit.