### PR TITLE
Ability to disable fulltext search index refresh

### DIFF
--- a/deployment/redesign-prod/helm/cityvizor/templates/server-kotlin.yml
+++ b/deployment/redesign-prod/helm/cityvizor/templates/server-kotlin.yml
@@ -43,6 +43,8 @@ spec:
               value: {{ .Values.server_kotlin.db_pass }}
             - name: googleCredentials
               value: file:/google-secret.json
+            - name: fulltextSearch.indexRefreshEnabled
+              value {{ .Values.server_kotlin.fulltextSearch.indexRefreshEnabled }}
           ports:
             - containerPort: 8080
           imagePullPolicy: Always

--- a/deployment/redesign-prod/helm/cityvizor/values.yaml
+++ b/deployment/redesign-prod/helm/cityvizor/values.yaml
@@ -25,6 +25,8 @@ server_kotlin:
   jdbc_url: jdbc:postgresql://db.cityvizor.cesko.digital:5432/cityvizor
   db_user: postgres
   db_pass: pass
+  fulltextSearch:
+    indexRefreshEnabled: true
 
 server_strapi:
   image: cityvizor/strapi-server

--- a/server-kotlin/src/main/kotlin/digital/cesko/full_text_search/service/IndexRefreshService.kt
+++ b/server-kotlin/src/main/kotlin/digital/cesko/full_text_search/service/IndexRefreshService.kt
@@ -8,12 +8,14 @@ import org.apache.lucene.index.IndexWriterConfig
 import org.apache.lucene.store.Directory
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import java.time.format.DateTimeFormatter
 import java.util.logging.Logger
 
 @Service
+@ConditionalOnProperty("fulltextSearch.indexRefreshEnabled")
 class IndexRefreshService(
         private val directory: Directory,
         private val searchService: SearchService

--- a/server-kotlin/src/main/resources/application.properties
+++ b/server-kotlin/src/main/resources/application.properties
@@ -15,5 +15,7 @@ city-request.listName=Seznam
 city-request.appName=CityVizor
 # City sync
 city-sync.instanceUrls.prague=https://cityvizor.praha.eu:8080
+# Fulltext search
+fulltextSearch.indexRefreshEnabled=true
 
 


### PR DESCRIPTION
There is not CityVizor database on redesign deployment
so this just fills logs with exceptions