### PR TITLE
Add a backlink text instead of a dedicated button. See #82

### DIFF
--- a/client/src/app/shared/components/header-menu/header-menu.component.html
+++ b/client/src/app/shared/components/header-menu/header-menu.component.html
@@ -1,16 +1,17 @@
 <header>
   <div class="container">
     <div class="row">
-      <div class="col-xs-12">
+      <div class="col-xs-6">
+        <h1 *ngIf="backLink">
+          <a [routerLink]="backLink" class="hidden-print">
+            CITYVIZOR
+          </a>
+        </h1>
+      </div>
+      <div class="col-xs-6">
         <h1 *ngIf="title">
           <a [routerLink]="title">{{title}}</a>
         </h1>
-
-        <h1 *ngIf="backLink" class="pull-right">
-            <a [routerLink]="backLink" class=" hidden-print">
-              <i class="fa fa-chevron-circle-left" aria-hidden="true"></i> ZPĚT
-            </a>
-          </h1>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Vychazel jsem z puvodniho obrazku v issue, protoze odkaz na Figma design chybi. Nove logo predpokladam jeste neni (podle gitu byla stavajici loga ve slozce `client/src/assets/img/favicon` pridana snad nekdy pred 17 mesici, tak jsem tam zatim dal jen ten text - viz prilozene obrazky. Kdyby bylo potreba to jeste vice upravit, neni problem.

![phone](https://user-images.githubusercontent.com/7964806/89332041-04f62c00-d693-11ea-9830-e3a0f5e0c297.png)
![large](https://user-images.githubusercontent.com/7964806/89332047-06275900-d693-11ea-9909-3b5642f14d2a.png)

Fixes #82.