### PR TITLE
 Ensure that login schema is same for frontend and backend

### DIFF
--- a/client/src/app/schema/credentials.ts
+++ b/client/src/app/schema/credentials.ts
@@ -1,0 +1,7 @@
+/*
+    username and password used to log in and change profile
+*/
+export class Credentials {
+    username: string;
+    password: string;
+}

--- a/client/src/app/services/auth.service.ts
+++ b/client/src/app/services/auth.service.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { JwtHelperService } from '@auth0/angular-jwt';
 
 import { UserToken } from "app/schema/user";
+import { Credentials } from "app/schema/credentials";
 
 import { DataService } from './data.service';
 import { environment } from 'environments/environment';
@@ -56,7 +57,7 @@ export class AuthService {
 	}
 
 	// get the token by credentials
-	login(credentials): Promise<any> {
+	login(credentials: Credentials): Promise<any> {
 
 		return new Promise((resolve, reject) => {
 


### PR DESCRIPTION
Na backendu je login schema které ověřuje že se posílá {"username": "string", "password": "string"}. Na frontendu nic takového není.  Login bere typ "any". Sjednocení je "nice to have".