### PR TITLE
Fix docker-compose hiding node_modules directories.

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,6 +12,7 @@ services:
             target: dev
         volumes:
             - ./client:/user/src/app
+            - /user/src/app/node_modules
         ports:
             - 4200:4200
             - 49153:49153
@@ -23,12 +24,14 @@ services:
             - 3000:3000
         volumes:
             - ./server:/user/src/app
+            - /user/src/app/node_modules
     cityvizor-worker:
         build:
             target: dev
         command: bash src/scripts/wait-for-it.sh -h db.cityvizor.cesko.digital -p 54342 -- npm run worker-dev
         volumes:
             - ./server:/user/src/app
+            - /user/src/app/node_modules
     backend-kotlin:
         ports:
             - 4203:8080

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /user/src/app
 
 # Install server dependencies
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm install
 
 FROM dev as prod
 # Copy server source code and build it


### PR DESCRIPTION
Za upozorneni na chybu dekuji Peterovi Tylkovi.

Pri bind mountovani adresaru s kodem pro development doslo k tomu, ze se tim schoval `node_modules` adresar, ktery tam predtim kontejner nainstaloval. Aplikace tedy pak spadla, protoze nemela nainstalovane zavislosti. Na chybu se prislo az ted, protoze jsem mel lokalne ten `node_modules` adresar nainstalovany (pozustatek z doby pred dockerem), pri bind-mountovani to tedy nespadlo.

