### PR TITLE
253 administration access

### DIFF
--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -11,6 +11,9 @@ const routes: Routes = [
 	/* FRONT PAGE */
 	{ path: '', component: FrontpageComponent },
 
+	/* NOT FOUND */
+	{ path: 'not-found', component: NotFoundPageComponent },
+
 	/* COUNTERPARTIES */
 	{ path: 'dodavatele', loadChildren: () => import("./views/counterparty/counterparty.module").then(mod => mod.CounterpartyModule) },
 
@@ -21,7 +24,7 @@ const routes: Routes = [
 	{ path: ':profile', loadChildren: () => import('./views/profile/profile.module').then(mod => mod.ProfileModule) },
 
 	/* CATCH ALL */
-	{ path: '**', pathMatch: 'full', component: NotFoundPageComponent },
+	{ path: '**', pathMatch: 'full', redirectTo: '/not-found' },
 
 
 ];

--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -4,6 +4,7 @@ import { ACLService } from "./services/acl.service";
 import { NgModule } from '@angular/core';
 
 import { FrontpageComponent } from './views/frontpage/frontpage.component';
+import { NotFoundPageComponent } from './views/not-found-page/not-found-page.component';
 
 const routes: Routes = [
 
@@ -20,7 +21,7 @@ const routes: Routes = [
 	{ path: ':profile', loadChildren: () => import('./views/profile/profile.module').then(mod => mod.ProfileModule) },
 
 	/* CATCH ALL */
-	{ path: '**', redirectTo: '', pathMatch: 'full' },
+	{ path: '**', pathMatch: 'full', component: NotFoundPageComponent },
 
 
 ];

--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -17,7 +17,11 @@ const routes: Routes = [
 	{ path: 'admin', loadChildren: () => import('./views/admin/admin.module').then(mod => mod.AdminModule), canActivate: [ACLService] },
 
 	/* PROFILE */
-	{ path: ':profile', loadChildren: () => import('./views/profile/profile.module').then(mod => mod.ProfileModule) }
+	{ path: ':profile', loadChildren: () => import('./views/profile/profile.module').then(mod => mod.ProfileModule) },
+
+	/* CATCH ALL */
+	{ path: '**', redirectTo: '', pathMatch: 'full' },
+
 
 ];
 

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
 import { SharedModule } from 'app/shared/shared.module';
 import { FrontpageModule } from './views/frontpage/frontpage.module';
+import { NotFoundPageModule } from './views/not-found-page/not-found-page.module';
 
 /* HTTP Interceptors */
 import { httpInterceptorProviders } from './http-interceptors';
@@ -41,7 +42,7 @@ var jwtOptions = {
 
 @NgModule({
 	imports: [
-		BrowserModule,
+	BrowserModule,
 		BrowserAnimationsModule,
 		HttpClientModule,
 		
@@ -49,6 +50,7 @@ var jwtOptions = {
 		
 		SharedModule,
 		FrontpageModule,
+		NotFoundPageModule,
 
 		ModalModule.forRoot(),
 		JwtModule.forRoot(jwtOptions)

--- a/client/src/app/http-interceptors/index.ts
+++ b/client/src/app/http-interceptors/index.ts
@@ -1,8 +1,10 @@
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 
 import { WithCredentialsInterceptor } from './with-credentials.interceptor';
+import { NotFoundInterceptor } from './not-found.interceptor';
 
 /** Http interceptor providers in outside-in order */
 export const httpInterceptorProviders = [
+  { provide: HTTP_INTERCEPTORS, useClass: NotFoundInterceptor, multi: true },
   { provide: HTTP_INTERCEPTORS, useClass: WithCredentialsInterceptor, multi: true },
 ];

--- a/client/src/app/http-interceptors/not-found.interceptor.ts
+++ b/client/src/app/http-interceptors/not-found.interceptor.ts
@@ -15,8 +15,7 @@ export class NotFoundInterceptor implements HttpInterceptor {
             .handle(req)
             .pipe(catchError( (error: HttpErrorResponse) => {
                     if ( error instanceof HttpErrorResponse && error.status == 404 ) {
-                        // seems more save to reload whole page and start over
-                        window.location.href = '/not-found';
+                        this.router.navigateByUrl('/not-found', {replaceUrl: true});
                         return EMPTY;
                     } else {
                         return throwError(error);

--- a/client/src/app/http-interceptors/not-found.interceptor.ts
+++ b/client/src/app/http-interceptors/not-found.interceptor.ts
@@ -1,0 +1,27 @@
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent, HttpResponse, HttpErrorResponse, HttpHeaderResponse, HttpProgressEvent, HttpSentEvent, HttpUserEvent } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import { EMPTY, Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+
+@Injectable()
+export class NotFoundInterceptor implements HttpInterceptor {
+
+    constructor(private router: Router) {}
+
+    intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpSentEvent | HttpHeaderResponse | HttpProgressEvent | HttpResponse<any> | HttpUserEvent<any>> {
+        return next
+            .handle(req)
+            .pipe(catchError( (error: HttpErrorResponse) => {
+                    if ( error instanceof HttpErrorResponse && error.status == 404 ) {
+                        // seems more save to reload whole page and start over
+                        window.location.href = '/not-found';
+                        return EMPTY;
+                    } else {
+                        return throwError(error);
+                    }
+                }
+            ));
+    }
+}

--- a/client/src/app/services/acl.service.ts
+++ b/client/src/app/services/acl.service.ts
@@ -62,7 +62,12 @@ export class ACLService implements CanActivate {
       let paramNamesMatches = routeDef.route.match(/\:[^\/]+/g);
       let paramNames = paramNamesMatches ? paramNamesMatches.map(item => item.substr(1)) : [];
       
-      let search = new RegExp("^" + routeDef.route.replace(/\:[^\/]+/g,"([^\/]+)") + "$");
+      // include subpages
+      // /admin => enabled is /admin, /admin/, /admin/* not /administrator
+      const routeWithoutSlash = routeDef.route[routeDef.route.length-1] === '/' ?
+        routeDef.route.slice(0, routeDef.route.length-1) : routeDef.route;
+      const routeWithoutParams = routeWithoutSlash.replace(/\:[^\/]+/g,"([^\/]+)")
+      let search = new RegExp(`^${routeWithoutParams}|${routeWithoutParams}/\.*$`);
 
       let matches = searchRoute.match(search);
       

--- a/client/src/app/shared/components/header-menu/header-menu.component.html
+++ b/client/src/app/shared/components/header-menu/header-menu.component.html
@@ -10,7 +10,7 @@
       </div>
       <div class="col-xs-6">
         <h1 *ngIf="title">
-          <a [routerLink]="title">{{title}}</a>
+          {{title}}
         </h1>
       </div>
     </div>

--- a/client/src/app/views/admin/admin-routing.module.ts
+++ b/client/src/app/views/admin/admin-routing.module.ts
@@ -9,7 +9,6 @@ import { AdminProfileSettingsComponent } from './views/admin-profile/admin-profi
 import { AdminProfileLogsComponent } from './views/admin-profile/admin-profile-logs/admin-profile-logs.component';
 import { AdminUserComponent } from './views/admin-user/admin-user.component';
 import { AdminProfileApiComponent } from './views/admin-profile/admin-profile-api/admin-profile-api.component';
-import { NotFoundPageComponent } from '../not-found-page/not-found-page.component';
 
 
 const routes: Routes = [

--- a/client/src/app/views/admin/admin-routing.module.ts
+++ b/client/src/app/views/admin/admin-routing.module.ts
@@ -9,6 +9,7 @@ import { AdminProfileSettingsComponent } from './views/admin-profile/admin-profi
 import { AdminProfileLogsComponent } from './views/admin-profile/admin-profile-logs/admin-profile-logs.component';
 import { AdminUserComponent } from './views/admin-user/admin-user.component';
 import { AdminProfileApiComponent } from './views/admin-profile/admin-profile-api/admin-profile-api.component';
+import { NotFoundPageComponent } from '../not-found-page/not-found-page.component';
 
 
 const routes: Routes = [
@@ -25,7 +26,7 @@ const routes: Routes = [
           { path: "logy", component: AdminProfileLogsComponent },
           { path: "nastaveni", component: AdminProfileSettingsComponent },
           { path: "", redirectTo: "data", pathMatch: "full" },
-	        { path: '**', redirectTo: '/', pathMatch: 'full' },
+	        { path: '**', pathMatch: 'full', component: NotFoundPageComponent },
         ]
       },
       { path: "profily", component: AdminProfileListComponent },
@@ -34,7 +35,7 @@ const routes: Routes = [
       { path: "spravci", component: AdminUserListComponent },
 
       { path: "", redirectTo: "profily", pathMatch: "full" },
-	    { path: '**', redirectTo: '/', pathMatch: 'full' },
+	    { path: '**', pathMatch: 'full', component: NotFoundPageComponent },
     ]
   }
 ];

--- a/client/src/app/views/admin/admin-routing.module.ts
+++ b/client/src/app/views/admin/admin-routing.module.ts
@@ -26,7 +26,7 @@ const routes: Routes = [
           { path: "logy", component: AdminProfileLogsComponent },
           { path: "nastaveni", component: AdminProfileSettingsComponent },
           { path: "", redirectTo: "data", pathMatch: "full" },
-	        { path: '**', pathMatch: 'full', component: NotFoundPageComponent },
+	        { path: '**', pathMatch: 'full', redirectTo: '/not-found' },
         ]
       },
       { path: "profily", component: AdminProfileListComponent },
@@ -35,7 +35,7 @@ const routes: Routes = [
       { path: "spravci", component: AdminUserListComponent },
 
       { path: "", redirectTo: "profily", pathMatch: "full" },
-	    { path: '**', pathMatch: 'full', component: NotFoundPageComponent },
+	    { path: '**', pathMatch: 'full', redirectTo: '/not-found' },
     ]
   }
 ];

--- a/client/src/app/views/admin/admin-routing.module.ts
+++ b/client/src/app/views/admin/admin-routing.module.ts
@@ -24,7 +24,8 @@ const routes: Routes = [
           { path: "api", component: AdminProfileApiComponent },
           { path: "logy", component: AdminProfileLogsComponent },
           { path: "nastaveni", component: AdminProfileSettingsComponent },
-          { path: "", redirectTo: "data", pathMatch: "full" }
+          { path: "", redirectTo: "data", pathMatch: "full" },
+	        { path: '**', redirectTo: '/', pathMatch: 'full' },
         ]
       },
       { path: "profily", component: AdminProfileListComponent },
@@ -32,7 +33,8 @@ const routes: Routes = [
       { path: "spravci/:user", component: AdminUserComponent },
       { path: "spravci", component: AdminUserListComponent },
 
-      { path: "", redirectTo: "profily", pathMatch: "full" }
+      { path: "", redirectTo: "profily", pathMatch: "full" },
+	    { path: '**', redirectTo: '/', pathMatch: 'full' },
     ]
   }
 ];

--- a/client/src/app/views/counterparty/counterparty-routing.module.ts
+++ b/client/src/app/views/counterparty/counterparty-routing.module.ts
@@ -6,7 +6,6 @@ import { CounterpartyComponent } from './counterparty.component';
 import { CounterpartyProfilesComponent } from './views/counterparty-profiles/counterparty-profiles.component';
 import { CounterpartyPaymentsComponent } from './views/counterparty-payments/counterparty-payments.component';
 import { CounterpartyDashboardComponent } from './views/counterparty-dashboard/counterparty-dashboard.component';
-import { NotFoundPageComponent } from '../not-found-page/not-found-page.component';
 
 const routes: Routes = [
   {

--- a/client/src/app/views/counterparty/counterparty-routing.module.ts
+++ b/client/src/app/views/counterparty/counterparty-routing.module.ts
@@ -6,6 +6,7 @@ import { CounterpartyComponent } from './counterparty.component';
 import { CounterpartyProfilesComponent } from './views/counterparty-profiles/counterparty-profiles.component';
 import { CounterpartyPaymentsComponent } from './views/counterparty-payments/counterparty-payments.component';
 import { CounterpartyDashboardComponent } from './views/counterparty-dashboard/counterparty-dashboard.component';
+import { NotFoundPageComponent } from '../not-found-page/not-found-page.component';
 
 const routes: Routes = [
   {
@@ -16,7 +17,7 @@ const routes: Routes = [
       { path: 'faktury', component: CounterpartyPaymentsComponent },
       { path: 'prehled', component: CounterpartyDashboardComponent },
       { path: '', redirectTo: 'prehled', pathMatch: 'full' },
-      { path: '**', redirectTo: '/', pathMatch: 'full' },
+      { path: '**', pathMatch: 'full', component: NotFoundPageComponent },
     ]
   }
 ];

--- a/client/src/app/views/counterparty/counterparty-routing.module.ts
+++ b/client/src/app/views/counterparty/counterparty-routing.module.ts
@@ -17,7 +17,7 @@ const routes: Routes = [
       { path: 'faktury', component: CounterpartyPaymentsComponent },
       { path: 'prehled', component: CounterpartyDashboardComponent },
       { path: '', redirectTo: 'prehled', pathMatch: 'full' },
-      { path: '**', pathMatch: 'full', component: NotFoundPageComponent },
+      { path: '**', pathMatch: 'full', redirectTo: '/not-found' },
     ]
   }
 ];

--- a/client/src/app/views/counterparty/counterparty-routing.module.ts
+++ b/client/src/app/views/counterparty/counterparty-routing.module.ts
@@ -15,7 +15,8 @@ const routes: Routes = [
       { path: 'obce', component: CounterpartyProfilesComponent },
       { path: 'faktury', component: CounterpartyPaymentsComponent },
       { path: 'prehled', component: CounterpartyDashboardComponent },
-      { path: '', redirectTo: 'prehled', pathMatch: 'full' }
+      { path: '', redirectTo: 'prehled', pathMatch: 'full' },
+      { path: '**', redirectTo: '/', pathMatch: 'full' },
     ]
   }
 ];

--- a/client/src/app/views/not-found-page/not-found-page.component.html
+++ b/client/src/app/views/not-found-page/not-found-page.component.html
@@ -1,0 +1,6 @@
+<h2>Chyba 404 – Stránka nenalezena</h2>
+
+<p>
+    Stránku se nepodařilo najít, litujeme.<br/>
+    Pokračujte na <a [routerLink]="['/']">Hlavní stránku</a>
+</p>

--- a/client/src/app/views/not-found-page/not-found-page.component.html
+++ b/client/src/app/views/not-found-page/not-found-page.component.html
@@ -2,5 +2,5 @@
 
 <p>
     Stránku se nepodařilo najít, litujeme.<br/>
-    Pokračujte na <a [routerLink]="['/']">Hlavní stránku</a>
+    Pokračujte na <a href="/">Hlavní stránku</a>
 </p>

--- a/client/src/app/views/not-found-page/not-found-page.component.ts
+++ b/client/src/app/views/not-found-page/not-found-page.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'not-found-page',
+    templateUrl: 'not-found-page.component.html'
+})
+
+export class NotFoundPageComponent {
+}

--- a/client/src/app/views/not-found-page/not-found-page.module.ts
+++ b/client/src/app/views/not-found-page/not-found-page.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { NotFoundPageComponent } from './not-found-page.component';
+
+@NgModule({
+    imports: [ RouterModule],
+    exports: [],
+    declarations: [NotFoundPageComponent],
+    providers: [],
+})
+export class NotFoundPageModule { }

--- a/client/src/app/views/profile/profile-routing.module.ts
+++ b/client/src/app/views/profile/profile-routing.module.ts
@@ -9,6 +9,7 @@ import { ProfileInvoicesComponent } from './views/profile-invoices/profile-invoi
 import { ProfileNoticeboardComponent } from './views/profile-noticeboard/profile-noticeboard.component';
 import { ProfileContractsComponent } from './views/profile-contracts/profile-contracts.component';
 import { ProfileCounterpartiesComponent } from './views/profile-counterparties/profile-counterparties.component';
+import { NotFoundPageComponent } from '../not-found-page/not-found-page.component';
 
 
 const routes: Routes = [
@@ -23,7 +24,7 @@ const routes: Routes = [
       { path: "registr-smluv", component: ProfileContractsComponent },
       { path: "dodavatele", component: ProfileCounterpartiesComponent },
       { path: "", redirectTo: "prehled", pathMatch: "full" },
-      { path: '**', redirectTo: '/', pathMatch: 'full' },
+      { path: '**', pathMatch: 'full', component: NotFoundPageComponent },
     ]
   }
 ];

--- a/client/src/app/views/profile/profile-routing.module.ts
+++ b/client/src/app/views/profile/profile-routing.module.ts
@@ -22,7 +22,8 @@ const routes: Routes = [
       { path: "uredni-deska", component: ProfileNoticeboardComponent },
       { path: "registr-smluv", component: ProfileContractsComponent },
       { path: "dodavatele", component: ProfileCounterpartiesComponent },
-      { path: "", redirectTo: "prehled", pathMatch: "full" }
+      { path: "", redirectTo: "prehled", pathMatch: "full" },
+      { path: '**', redirectTo: '/', pathMatch: 'full' },
     ]
   }
 ];

--- a/client/src/app/views/profile/profile-routing.module.ts
+++ b/client/src/app/views/profile/profile-routing.module.ts
@@ -9,7 +9,6 @@ import { ProfileInvoicesComponent } from './views/profile-invoices/profile-invoi
 import { ProfileNoticeboardComponent } from './views/profile-noticeboard/profile-noticeboard.component';
 import { ProfileContractsComponent } from './views/profile-contracts/profile-contracts.component';
 import { ProfileCounterpartiesComponent } from './views/profile-counterparties/profile-counterparties.component';
-import { NotFoundPageComponent } from '../not-found-page/not-found-page.component';
 
 
 const routes: Routes = [

--- a/client/src/app/views/profile/profile-routing.module.ts
+++ b/client/src/app/views/profile/profile-routing.module.ts
@@ -24,7 +24,7 @@ const routes: Routes = [
       { path: "registr-smluv", component: ProfileContractsComponent },
       { path: "dodavatele", component: ProfileCounterpartiesComponent },
       { path: "", redirectTo: "prehled", pathMatch: "full" },
-      { path: '**', pathMatch: 'full', component: NotFoundPageComponent },
+      { path: '**', pathMatch: 'full', redirectTo: '/not-found' },
     ]
   }
 ];


### PR DESCRIPTION
* acl.service - enhanced route checking includes check for subpages e.g. /admin => enabled is /admin, /admin/, /admin/* not /administrator
* bare bones not-found page to which is user redirected in case of any 404 error (by interceptor) or by app routing
* header title is plain text without routing, which afaik did not work