### PR TITLE
Fix linter errors

### DIFF
--- a/server-kotlin/build.gradle
+++ b/server-kotlin/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.spring' version "$kotlin_version"
     id 'com.google.cloud.tools.jib' version '2.2.0'
     id 'com.github.ben-manes.versions' version '0.33.0'
-    id 'org.jlleitschuh.gradle.ktlint' version '9.4.0'
+    id 'org.jlleitschuh.gradle.ktlint' version '9.4.1'
 }
 
 group 'digital.cesko'

--- a/server-kotlin/src/main/kotlin/digital/cesko/internet_stream/InternetStreamService.kt
+++ b/server-kotlin/src/main/kotlin/digital/cesko/internet_stream/InternetStreamService.kt
@@ -10,7 +10,6 @@ import org.jetbrains.exposed.sql.batchInsert
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Profile
 import org.springframework.core.io.ResourceLoader
@@ -151,7 +150,8 @@ class InternetStreamService(
 
     fun saveCityBudgets(cityId: Int, allBudgets: List<Budget>) {
         allBudgets.chunked(threshold) {
-            budgets: List<Budget> -> insertIntoPayments(cityId, budgets)
+            budgets: List<Budget> ->
+            insertIntoPayments(cityId, budgets)
         }
     }
 


### PR DESCRIPTION
Fix 2 lint errors. Upgrade linter to v 9.4.1. Previous version did not work correctly on Windows and did not show errors. The errors were visible only during build on Ubuntu.