### PR TITLE
Integrate Vue app into Angular.

### DIFF
--- a/client/src/app/shared/components/header-menu/header-menu.component.html
+++ b/client/src/app/shared/components/header-menu/header-menu.component.html
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-xs-6">
         <h1 *ngIf="backLink">
-          <a [routerLink]="backLink" class="hidden-print">
+          <a href="/" class="hidden-print">
             CITYVIZOR
           </a>
         </h1>

--- a/deployment/redesign-prod/helm/cityvizor/templates/cityvizor-client.yml
+++ b/deployment/redesign-prod/helm/cityvizor/templates/cityvizor-client.yml
@@ -1,4 +1,3 @@
-{{- if .Values.vintage_enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -32,7 +31,6 @@ spec:
       containers:
         - name: cityvizor-client
           image: {{ .Values.cityvizor_client.image }}:{{ .Values.cityvizor_client.tag }}
-          env:
             - name: NODE_ENV
               value: "prod"
           ports:
@@ -44,4 +42,3 @@ spec:
               port: 80
             initialDelaySeconds: 3
             periodSeconds: 3
-{{- end -}}

--- a/deployment/redesign-prod/helm/cityvizor/templates/cityvizor-server.yml
+++ b/deployment/redesign-prod/helm/cityvizor/templates/cityvizor-server.yml
@@ -1,8 +1,3 @@
-{{- if .Values.vintage_enabled -}}
-apiVersion: v1
-kind: Service
-metadata:
-  name: cityvizor-server
 spec:
   ports:
     - nodePort: 32311
@@ -66,4 +61,3 @@ spec:
         - name: import-data
           persistentVolumeClaim:
             claimName: 'import-pvc'
-{{ end }}

--- a/deployment/redesign-prod/helm/cityvizor/templates/cityvizor-server.yml
+++ b/deployment/redesign-prod/helm/cityvizor/templates/cityvizor-server.yml
@@ -1,3 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cityvizor-server
 spec:
   ports:
     - nodePort: 32311

--- a/deployment/redesign-prod/helm/cityvizor/templates/cityvizor-worker.yml
+++ b/deployment/redesign-prod/helm/cityvizor/templates/cityvizor-worker.yml
@@ -1,4 +1,3 @@
-{{- if .Values.vintage_enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,4 +41,3 @@ spec:
         - name: import-data
           persistentVolumeClaim:
             claimName: "import-pvc"
-{{- end -}}

--- a/deployment/redesign-prod/helm/cityvizor/templates/ingress.yml
+++ b/deployment/redesign-prod/helm/cityvizor/templates/ingress.yml
@@ -1,22 +1,21 @@
+
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: cityvizor-ingress
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location = / {
+        return 302 /landing;
+      }
 spec:
   tls:
     - hosts:
-        {{- if .Values.vintage_enabled }}
-        - {{ .Values.ingress.main_host }}
-        {{ end }}
-        {{- if .Values.landing_page_enabled }}
-        - {{ .Values.ingress.landing_page_host }}
-        {{ end }}
+        - {{ .Values.ingress.host }}
       secretName: cityvizor-tls
   rules:
-    {{- if .Values.vintage_enabled }}
-    - host: {{ .Values.ingress.main_host }}
+    - host: {{ .Values.ingress.host }}
       http:
         paths:
           - path: /api/v2/
@@ -31,25 +30,11 @@ spec:
             backend:
               serviceName: cityvizor-server
               servicePort: 3000
+          - path: /landing
+            backend:
+              serviceName: landing-page
+              servicePort: 80
           - path: /
             backend:
               serviceName: cityvizor-client
               servicePort: 80
-    {{ end }}
-    {{- if .Values.landing_page_enabled }}
-    - host: {{ .Values.ingress.landing_page_host }}
-      http:
-        paths:
-          - path: /api/v2/
-            backend:
-              serviceName: server-kotlin
-              servicePort: 8080
-          - path: /api/v1/citysync
-            backend:
-              serviceName: server-kotlin
-              servicePort: 8080
-          - path: /
-            backend:
-              serviceName: landing-page
-              servicePort: 80
-    {{ end }}

--- a/deployment/redesign-prod/helm/cityvizor/templates/landing-page.yml
+++ b/deployment/redesign-prod/helm/cityvizor/templates/landing-page.yml
@@ -1,4 +1,3 @@
-{{- if .Values.landing_page_enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -41,4 +40,3 @@ spec:
               port: 80
             initialDelaySeconds: 3
             periodSeconds: 3
-{{- end -}}

--- a/deployment/redesign-prod/helm/cityvizor/values.yaml
+++ b/deployment/redesign-prod/helm/cityvizor/values.yaml
@@ -2,11 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Is landing page enabled
-landing_page_enabled: true
-# Are cityvizor-server and cityvizor-client enabled?
-vintage_enabled: true
-
 cityvizor_server:
   image: cityvizor/cityvizor-server
   tag: prod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,7 @@ services:
     image: nginx:1.15.8-alpine
     container_name: nginx.cityvizor.cesko.digital
     ports:
-      # Client
       - "4200:80"
-      # Landing page
-      - "4201:81"
     volumes:
       - ./nginx:/etc/nginx:ro
     environment:

--- a/landing-page/nginx/client-server.conf
+++ b/landing-page/nginx/client-server.conf
@@ -1,6 +1,7 @@
 server {
     
     listen       80;    
+    rewrite ^/landing/(.*)$ /$1;
 
     location / {
         root   /usr/share/nginx/html;

--- a/landing-page/src/router/index.js
+++ b/landing-page/src/router/index.js
@@ -3,6 +3,7 @@ import Router from 'vue-router';
 import WhyPage from '../components/pages/WhyPage'
 import MarkdownPage from '../components/pages/MarkdownPage'
 import Home from '../components/pages/Home';
+import { publicPath } from "../../vue.config"
 
 Vue.use(Router);
 
@@ -53,5 +54,6 @@ const routes = [
 
 export default new Router({
     mode: 'history',
-    routes
+    routes,
+    base: publicPath
 })

--- a/landing-page/vue.config.js
+++ b/landing-page/vue.config.js
@@ -20,5 +20,6 @@ module.exports = {
             },
             ],
         },
-    }
+    },
+    publicPath: process.env.VUE_PUBLIC_PATH || "/landing"
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -30,9 +30,24 @@ http {
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
+
     location  /api {
       set                $upstream_server http://server.cityvizor.cesko.digital:3000;
       proxy_pass         $upstream_server;
+      proxy_redirect     off;
+      proxy_set_header   Host $host;
+    }
+
+    location = / {
+      set                $upstream_server http://landing.cityvizor.cesko.digital:80/landing/;
+      proxy_pass         $upstream_server;
+      proxy_redirect     off;
+      proxy_set_header   Host $host;
+    }
+   z 
+    location /landing {
+      set                $upstream_client http://landing.cityvizor.cesko.digital:80;
+      proxy_pass         $upstream_client;
       proxy_redirect     off;
       proxy_set_header   Host $host;
     }
@@ -43,26 +58,6 @@ http {
       proxy_redirect     off;
       proxy_set_header   Host $host;
     }
-  }
 
-  server {
-    listen 81;
-
-    location / {
-      set                $upstream_client http://landing.cityvizor.cesko.digital:80;
-      proxy_pass         $upstream_client;
-      proxy_redirect     off;
-      proxy_set_header   Host $host;
-      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-
-    # To enable use of relative paths in redesign client API paths
-    location  /api/v2/ {
-      set                $upstream_backend http://backend.cityvizor.cesko.digital:8080;
-      proxy_pass         $upstream_backend;
-      proxy_redirect     off;
-      proxy_set_header   Host $host;
-      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
   }
 }


### PR DESCRIPTION
Cilem PR je zintegrovat landing page ve Vue do Angularu tak, aby se to zvenci tvarilo jako jedna samostatna stranka. Kladl jsem duraz na nulovy coupling tech dvou aplikaci, aby byl pripadny refactoring jednodussi. Celou Vue appku jsem strcil do samostatneho `/landing` adresare.

- Uprava docker-compose a nginx proxy pro lokalni simulaci produkcniho prostredi
- Uprava k8s konfiguraku se semanticky stejnym vyznamem
- Backlink (text "Cityvizor") v Angular appce jsem nahradil odkazem na `/`, aby se spravne presmerovalo na landing page.

Konkretni chovani lze vyzkouset na https://cityvizor-test.ceskodigital.net/ (V ramci testovani PR jsem tam uz provedl upravy, ktere jsou v PR). 

- https://cityvizor-test.ceskodigital.net/ se  presmeruje na https://cityvizor-test.ceskodigital.net/landing
- Backlink (vlevo nahore) v https://cityvizor-test.ceskodigital.net/praha1/prehled presmeruje na landing stranku.

