### PR TITLE
Hardlink Landing page header to prod

### DIFF
--- a/landing-page/src/components/partials/Header.vue
+++ b/landing-page/src/components/partials/Header.vue
@@ -10,13 +10,12 @@
             <div class="col-4 col-md-4">
 
                 <!-- Brand -->
-                <router-link to="/"
-                    class="c-brand">
+                <a href="https://cityvizor.cz">
                     <img 
                     src="./../../assets/images/logo.svg" 
                     width="280" 
                     alt="CityVizor.cz - logo">
-                </router-link>
+                </a>
 
             </div>
             <div class="col-8 col-md-8 text-right">


### PR DESCRIPTION
Nepříjemná situace:

Na produkci se (mojí vinou) dostaly linky, které odkazujou na cityvizor.cesko.digital, což je landing page kde se automaticky nasazujou latest tagy docker images (tedy to, co je v masteru). Jenže z landing page se nedá dostat zpět na produkci. Upravil jsem ten header tak, aby proklikával na produkci; tzn. aby se z landing page dalo dostat zpět do aplikace. Je to hack a dočasné řešení, které odstraníme, až se *konečně* vyřeší to nasazování.