### PR TITLE
Raise the upload limit

### DIFF
--- a/deployment/redesign-prod/helm/cityvizor/templates/ingress.yml
+++ b/deployment/redesign-prod/helm/cityvizor/templates/ingress.yml
@@ -5,6 +5,7 @@ metadata:
   name: cityvizor-ingress
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.upload-limit }}
     nginx.ingress.kubernetes.io/server-snippet: |
       location = / {
         return 302 /landing;

--- a/deployment/redesign-prod/helm/cityvizor/values.yaml
+++ b/deployment/redesign-prod/helm/cityvizor/values.yaml
@@ -39,7 +39,9 @@ shared_env:
 
 shared_env:
   images_url: https://cityvizor-images.s3.eu-central-1.amazonaws.com/
-    
+
+upload_limit: 10m
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
Při deploy přes k8s se používá nginx jako server a reverzní proxy. Nginx má defaultní hodnotu `client_max_body_size` na 1m, takže se dají nahrávat data maximálně do velikosti 1MB. Což je problém, protože při importu dat do CV mohou soubory být daleko větší. [Zvednul](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-max-body-size) jsem ten limit na default 10MB. 