### PR TITLE
Listen on ipv6 as well

### DIFF
--- a/client/nginx/client-server.conf
+++ b/client/nginx/client-server.conf
@@ -1,6 +1,7 @@
 server {
-    
-    listen       80;    
+
+    listen 0.0.0.0:80;
+    listen [::]:80;
 
     location / {
         root   /usr/share/nginx/html;

--- a/landing-page/nginx/client-server.conf
+++ b/landing-page/nginx/client-server.conf
@@ -1,6 +1,8 @@
 server {
-    
-    listen       80;    
+
+    listen 0.0.0.0:80;
+    listen [::]:80;
+
     rewrite ^/landing/(.*)$ /$1;
 
     location / {

--- a/server/environment/environment.local.js
+++ b/server/environment/environment.local.js
@@ -6,7 +6,7 @@ const cityvizorPath = path.resolve(__dirname,"../../");
 module.exports = {
 
   port: 3000,
-  host: "0.0.0.0",
+  host: "::",
 
   url: "http://localhost:4200",
 

--- a/server/environment/environment.system.js
+++ b/server/environment/environment.system.js
@@ -6,7 +6,7 @@ const cityvizorPath = path.resolve(__dirname,"../../");
 module.exports = {
 
   port: 3000,
-  host: "0.0.0.0",
+  host: "::",
 
   url: process.env.URL,
 


### PR DESCRIPTION
For node `::` means dual stack, so it listens
on both v6 and v4 interfaces by default.

This won't change anything when using docker with only v4
stack but makes it less error-prone when v6 is enabled
on both host and for docker containers since nginx proxy
can just refer to `localhost` and this can resolve to either
address:

```
127.0.0.1 localhost
::1 localhost
```