### PR TITLE
Fixed avatar upload in  administration

### DIFF
--- a/client/src/app/views/admin/views/admin-profile/admin-profile-settings/admin-profile-settings.component.html
+++ b/client/src/app/views/admin/views/admin-profile/admin-profile-settings/admin-profile-settings.component.html
@@ -15,7 +15,7 @@
       </div>
       <div class="form-group">
         <label>IČO</label>
-        <input type="text" name="ico" [ngModel]="profile?.ico" (ngModelChange)="icoAutofill($event)" class="form-control" #icoInput>
+        <input type="text" name="ico" [ngModel]="profile?.ico" class="form-control" #icoInput>
       </div>
       <div class="form-group">
         <label>Souřadnice</label>

--- a/client/src/app/views/admin/views/admin-profile/admin-profile-settings/admin-profile-settings.component.ts
+++ b/client/src/app/views/admin/views/admin-profile/admin-profile-settings/admin-profile-settings.component.ts
@@ -52,26 +52,6 @@ export class AdminProfileSettingsComponent implements OnInit {
 
   }
 
-  async icoAutofill(ico: string) {
-    if (/\d{8}/.test(ico)) {
-      const results = await this.dataService.searchForCities(ico)
-      if (results.length == 1) {
-        const data = results[0]
-
-        // The coords from the search are too long and will fail the validation, so trim them
-        const trim = (coords: number) => Number(coords.toString().substring(0, 10))
-        this.profile.gpsX = trim(data.souradnice[0])
-        this.profile.gpsY = trim(data.souradnice[1])
-        if (this.profile.avatarUrl == null || data.urlZnak) {
-          await this.adminService.saveProfileAvatarFromUrl(this.profile.id, data.urlZnak)
-          // Force the avatar to show without reloading the page (reloading would result in loss of autofilled coords)
-          this.profile.avatarType = data.urlZnak
-        }
-        
-      }
-  }
-}
-
   async uploadAvatar(fileInput: HTMLInputElement) {
     const file = fileInput.files ? fileInput.files[0] : null;
     if (!file) return;
@@ -85,6 +65,12 @@ export class AdminProfileSettingsComponent implements OnInit {
       return;
     }
 
+    const allowedTypes = ['png', 'jpg', 'jpe', 'jpeg', 'gif', 'svg'];
+    const extension = file.name.split(".").pop() || ""
+    if (allowedTypes.indexOf(extension) == -1) {
+      this.toastService.toast(`Nepovolený formát souboru. Povolené formáty: ${allowedTypes.join(", ")}`, "notice");
+      return;
+    }
     await this.adminService.saveProfileAvatar(this.profile.id, formData);
     this.reloadProfile();
 

--- a/server/src/routers/admin/profiles.ts
+++ b/server/src/routers/admin/profiles.ts
@@ -96,7 +96,7 @@ router.put(
       .first();
     if (!profile) return res.sendStatus(404);
 
-    const allowedTypes = ['.png', '.jpg', '.jpe', '.gif', '.svg'];
+    const allowedTypes = ['.png', '.jpg', '.jpe', '.jpeg', '.gif', '.svg'];
 
     const extname = req.file
       ? path.extname(req.file.originalname).toLowerCase()


### PR DESCRIPTION
Fixnul jsem bug v administraci kdy při pokusu o nahrání obrázku se špatnou příponou se neukázala error hláška. Zároveň jsem taky odebral funkcionalitu automatického nahrávání avataru a doplnění GPS souřadnic po vložení IČO, protože se brala z [datasetu](https://github.com/cesko-digital/obce) poskytovaného Kotlin backendem. V budoucnu to tam můžem vrátit, ale nemyslím si, že ten business value je tak velkej. 