### PR TITLE
Use Redis to cache API public GET responses in case HTTP:200 and content is returned

### DIFF
--- a/deployment/redesign-prod/helm/cityvizor/templates/cityvizor-server.yml
+++ b/deployment/redesign-prod/helm/cityvizor/templates/cityvizor-server.yml
@@ -51,6 +51,12 @@ spec:
               value: {{ .Values.cityvizor_server.jwt_secret }}
             - name: PRODUCTBOARD_TOKEN
               value: {{ .Values.productboard_token }}
+            - name: REDIS_HOST
+              value: {{ .Values.cityvizor_server.redis_host }}
+            - name: REDIS_PORT
+              value: {{ .Values.cityvizor_server.redis_port }}
+            - name: REDIS_TTL
+              value: {{ .Values.cityvizor_server.redis_ttl }}
           ports:
             - containerPort: 3000
           volumeMounts:

--- a/deployment/redesign-prod/helm/cityvizor/values.yaml
+++ b/deployment/redesign-prod/helm/cityvizor/values.yaml
@@ -12,6 +12,9 @@ cityvizor_server:
   create_admin: false
   jwt_secret: secret
   edesky_api_key: null
+  redis_host: localhost
+  redis_port: 6379
+  redis_ttl: 60
 
 cityvizor_client:
   image: cityvizor/cityvizor-client

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,3 +81,7 @@ services:
       - ./database/demo_dump.sql:/docker-entrypoint-initdb.d/demo_dump.sql
     ports:
       - 5432:5432
+
+  redis.cityvizor.otevrenamesta:
+    image: redis:6
+    container_name: redis.cityvizor.otevrenamesta

--- a/server/environment/environment.local.js
+++ b/server/environment/environment.local.js
@@ -24,6 +24,13 @@ module.exports = {
     database: 'cityvizor',
   },
 
+  redis: {
+    port: 6379,
+    host: 'redis.cityvizor.otevrenamesta',
+    // 10 minutes
+    ttl: 600,
+  },
+
   cors: true,
   corsOrigin: [
     'http://localhost:4200',

--- a/server/environment/environment.system.js
+++ b/server/environment/environment.system.js
@@ -26,6 +26,13 @@ module.exports = {
     ssl: !!process.env.DATABASE_SSL,
   },
 
+  redis: {
+    port: process.env.REDIS_PORT || 6379,
+    host: process.env.REDIS_HOST || 'redis.cityvizor.otevrenamesta',
+    // 10 minutes
+    ttl: process.env.REDIS_TTL || 600,
+  },
+
   cors: true,
   corsOrigin: process.env.URL,
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -21,9 +21,12 @@
         "cron": "^1.7.2",
         "csv-parse": "^4.15.1",
         "csv-stringify": "^5.3.4",
+        "debug": "^4.3.1",
+        "expeditious-engine-redis": "^0.1.2",
         "express": "^4.16.4",
         "express-async-errors": "^3.1.1",
         "express-dynacl": "^2.1.1",
+        "express-expeditious": "^5.1.1",
         "express-jsonschema": "^1.1.6",
         "express-jwt": "^6.0.0",
         "extract-zip": "^2.0.1",
@@ -735,6 +738,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/assign-symbols": {
@@ -2115,6 +2126,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+    },
     "node_modules/duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -2678,6 +2694,104 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expeditious": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/expeditious/-/expeditious-1.0.1.tgz",
+      "integrity": "sha1-mVt6x2dBpmApiRRJ1YZ7zMM4sw8=",
+      "dependencies": {
+        "debug": "~2.6.9",
+        "safejson": "~1.0.1",
+        "verror": "~1.6.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/expeditious-engine-memory": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/expeditious-engine-memory/-/expeditious-engine-memory-0.2.1.tgz",
+      "integrity": "sha1-zh2cvfLfmn25HNkZE8KLpTeWXRE=",
+      "dependencies": {
+        "expeditious": "~1.0.0"
+      }
+    },
+    "node_modules/expeditious-engine-redis": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/expeditious-engine-redis/-/expeditious-engine-redis-0.1.2.tgz",
+      "integrity": "sha512-qYC3PZ+6oSQbgGXCUOg5D4mbqQrLoxfMR90HAicDtCwTm27Dc+9yVuxWeKqVUpNjpTHyNWw+Z7E+/enIDjuOfQ==",
+      "dependencies": {
+        "async": "~2.0.0",
+        "expeditious": "~0.1.0",
+        "redis": "~2.6.2",
+        "verror": "~1.9.0"
+      },
+      "engines": {
+        "node": ">=4.4"
+      }
+    },
+    "node_modules/expeditious-engine-redis/node_modules/async": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+      "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+      "dependencies": {
+        "lodash": "^4.8.0"
+      }
+    },
+    "node_modules/expeditious-engine-redis/node_modules/expeditious": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/expeditious/-/expeditious-0.1.0.tgz",
+      "integrity": "sha1-vm9vkSJQbW3ME3ZYx2hGQJtG/zQ=",
+      "dependencies": {
+        "safejson": "^1.0.1",
+        "verror": "^1.6.1"
+      }
+    },
+    "node_modules/expeditious-engine-redis/node_modules/verror": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.9.0.tgz",
+      "integrity": "sha1-EHqKLRTDNYb8S7gwBXzS0Zripu4=",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/expeditious/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/expeditious/node_modules/extsprintf": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
+      "integrity": "sha1-WtlGwi9bMrp/jNdCZxHG6KP8JSk=",
+      "engines": [
+        "node >=0.6.0"
+      ]
+    },
+    "node_modules/expeditious/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/expeditious/node_modules/verror": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.1.tgz",
+      "integrity": "sha1-I2QCBgZIwhnRFiwkUdHDQaDhyc4=",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.2.0"
+      }
+    },
     "node_modules/express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -2729,6 +2843,31 @@
       "integrity": "sha512-ypKBROS4PBKk33nG7IRraWJxOMgeaE2XTdOD5tEpuUXBav7+/H2e4W9HzY77v5LwvyL7x66lkAjSImvFEfUDpQ==",
       "dependencies": {
         "chalk": "^2.4.1"
+      }
+    },
+    "node_modules/express-expeditious": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/express-expeditious/-/express-expeditious-5.1.1.tgz",
+      "integrity": "sha512-4akMwHm8TVRYzm/HQ520fJxqT1NIEb0J+CNzJ18l1kXt0GSnIHsRt2WpoI+8jdD/g3tf/Ggz+vbW6rwronJdvA==",
+      "dependencies": {
+        "debug": "~4.1.0",
+        "expeditious": "~1.0.1",
+        "expeditious-engine-memory": "~0.2.0",
+        "on-finished": "~2.3.0",
+        "timestring": "~5.0.0",
+        "verror": "~1.10.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express-expeditious/node_modules/debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/express-jsonschema": {
@@ -2929,6 +3068,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/extsprintf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz",
+      "integrity": "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=",
+      "engines": [
+        "node >=0.6.0"
+      ]
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -6284,6 +6431,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/redis": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.6.5.tgz",
+      "integrity": "sha1-h8Hv9KSJ+Utwhx89CLaYjyOpVoc=",
+      "dependencies": {
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "node_modules/redis-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -6502,6 +6675,11 @@
       "dependencies": {
         "ret": "~0.1.10"
       }
+    },
+    "node_modules/safejson": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safejson/-/safejson-1.0.1.tgz",
+      "integrity": "sha1-W8u5UzuW/OEOY1b0IAF8FqT5yZg="
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -7218,6 +7396,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/timestring": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/timestring/-/timestring-5.0.1.tgz",
+      "integrity": "sha512-0VfOVpaTYqBMTEpjwcY5mB+72YYjFI44Z5F2q80ZiIyDn5pRJm+rEV1OEM8xfnf5/FdtckcrTERTp9TbrlMMHw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -7774,6 +7960,19 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/which": {
@@ -8593,6 +8792,11 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -9738,6 +9942,11 @@
         "is-obj": "^2.0.0"
       }
     },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -10184,6 +10393,93 @@
         "homedir-polyfill": "^1.0.1"
       }
     },
+    "expeditious": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/expeditious/-/expeditious-1.0.1.tgz",
+      "integrity": "sha1-mVt6x2dBpmApiRRJ1YZ7zMM4sw8=",
+      "requires": {
+        "debug": "~2.6.9",
+        "safejson": "~1.0.1",
+        "verror": "~1.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "extsprintf": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
+          "integrity": "sha1-WtlGwi9bMrp/jNdCZxHG6KP8JSk="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "verror": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.1.tgz",
+          "integrity": "sha1-I2QCBgZIwhnRFiwkUdHDQaDhyc4=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "extsprintf": "1.2.0"
+          }
+        }
+      }
+    },
+    "expeditious-engine-memory": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/expeditious-engine-memory/-/expeditious-engine-memory-0.2.1.tgz",
+      "integrity": "sha1-zh2cvfLfmn25HNkZE8KLpTeWXRE=",
+      "requires": {
+        "expeditious": "~1.0.0"
+      }
+    },
+    "expeditious-engine-redis": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/expeditious-engine-redis/-/expeditious-engine-redis-0.1.2.tgz",
+      "integrity": "sha512-qYC3PZ+6oSQbgGXCUOg5D4mbqQrLoxfMR90HAicDtCwTm27Dc+9yVuxWeKqVUpNjpTHyNWw+Z7E+/enIDjuOfQ==",
+      "requires": {
+        "async": "~2.0.0",
+        "expeditious": "~0.1.0",
+        "redis": "~2.6.2",
+        "verror": "~1.9.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+          "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+          "requires": {
+            "lodash": "^4.8.0"
+          }
+        },
+        "expeditious": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/expeditious/-/expeditious-0.1.0.tgz",
+          "integrity": "sha1-vm9vkSJQbW3ME3ZYx2hGQJtG/zQ=",
+          "requires": {
+            "safejson": "^1.0.1",
+            "verror": "^1.6.1"
+          }
+        },
+        "verror": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.9.0.tgz",
+          "integrity": "sha1-EHqKLRTDNYb8S7gwBXzS0Zripu4=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        }
+      }
+    },
     "express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -10252,6 +10548,29 @@
       "integrity": "sha512-ypKBROS4PBKk33nG7IRraWJxOMgeaE2XTdOD5tEpuUXBav7+/H2e4W9HzY77v5LwvyL7x66lkAjSImvFEfUDpQ==",
       "requires": {
         "chalk": "^2.4.1"
+      }
+    },
+    "express-expeditious": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/express-expeditious/-/express-expeditious-5.1.1.tgz",
+      "integrity": "sha512-4akMwHm8TVRYzm/HQ520fJxqT1NIEb0J+CNzJ18l1kXt0GSnIHsRt2WpoI+8jdD/g3tf/Ggz+vbW6rwronJdvA==",
+      "requires": {
+        "debug": "~4.1.0",
+        "expeditious": "~1.0.1",
+        "expeditious-engine-memory": "~0.2.0",
+        "on-finished": "~2.3.0",
+        "timestring": "~5.0.0",
+        "verror": "~1.10.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "express-jsonschema": {
@@ -10392,6 +10711,11 @@
           }
         }
       }
+    },
+    "extsprintf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz",
+      "integrity": "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -13009,6 +13333,26 @@
         "strip-indent": "^3.0.0"
       }
     },
+    "redis": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.6.5.tgz",
+      "integrity": "sha1-h8Hv9KSJ+Utwhx89CLaYjyOpVoc=",
+      "requires": {
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.0.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "redis-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+    },
     "reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -13180,6 +13524,11 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "safejson": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safejson/-/safejson-1.0.1.tgz",
+      "integrity": "sha1-W8u5UzuW/OEOY1b0IAF8FqT5yZg="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -13785,6 +14134,11 @@
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
       "integrity": "sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw=="
     },
+    "timestring": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/timestring/-/timestring-5.0.1.tgz",
+      "integrity": "sha512-0VfOVpaTYqBMTEpjwcY5mB+72YYjFI44Z5F2q80ZiIyDn5pRJm+rEV1OEM8xfnf5/FdtckcrTERTp9TbrlMMHw=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -14243,6 +14597,16 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/server/package.json
+++ b/server/package.json
@@ -46,9 +46,12 @@
     "cron": "^1.7.2",
     "csv-parse": "^4.15.1",
     "csv-stringify": "^5.3.4",
+    "debug": "^4.3.1",
+    "expeditious-engine-redis": "^0.1.2",
     "express": "^4.16.4",
     "express-async-errors": "^3.1.1",
     "express-dynacl": "^2.1.1",
+    "express-expeditious": "^5.1.1",
     "express-jsonschema": "^1.1.6",
     "express-jwt": "^6.0.0",
     "extract-zip": "^2.0.1",
@@ -86,6 +89,9 @@
     "nodemon": "^2.0.7",
     "tslint": "^6.1.3",
     "typescript": "^4.1.3"
+  },
+  "resolutions": {
+    "debug": "^4.3.1"
   },
   "engines": {
     "node": ">=12"

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -19,6 +19,12 @@ export default {
     allowedHeaders: ['Authorization', 'Content-Type'],
   },
 
+  redis: {
+    host: environment.redis.host,
+    port: environment.redis.port,
+    ttl: environment.redis.ttl,
+  },
+
   cron: {
     cronTime: '00 00 07 * * *',
     runOnInit: false,

--- a/server/src/routers/index.ts
+++ b/server/src/routers/index.ts
@@ -1,6 +1,20 @@
 import express from 'express';
+import getExpeditiousCache from 'express-expeditious';
+import redisEngine from 'expeditious-engine-redis';
+import config from '../config';
 
 const router = express.Router();
+
+const cache = getExpeditiousCache({
+  namespace: 'cv',
+  defaultTtl: '5 minutes',
+  engine: redisEngine({
+    redis: {
+      host: config.redis.host,
+      port: config.redis.port,
+    },
+  }),
+});
 
 export const Routers = router;
 
@@ -16,7 +30,7 @@ router.use('/api/account', AccountRouter);
 
 router.use('/api/admin', AdminRouter);
 
-router.use('/api/public', PublicRouter);
+router.use('/api/public', cache, PublicRouter);
 
 router.use('/api/import', ImportRouter);
 


### PR DESCRIPTION
- Cache handler: https://github.com/evanshortiss/express-expeditious
- Cache engine: https://www.npmjs.com/package/expeditious-engine-redis

Mělo by to být v pohodě konfigurovatelné, do docker-compose jsem přidal novou definici hostu `redis.cityvizor.otevrenamesta`

Vzhledem k tomu, že na aktuální staging běží server (api) 3x, tak je to lepší než ten in-memory caching, který by ty jednotlivé workers nesdíleli

@sorki pro tebe FYI, že budeme potřebovat pustit redis na adrese `redis.cityvizor.otevrenamesta` v rámci nix
@srdecny prosím otestuj si lokálně že ti to funguje, případně budu rád za hezčí integraci, pokud tě napadne jak