### PR TITLE
Set port for dev mode to be the same as is in prod mode

### DIFF
--- a/landing-page/vue.config.js
+++ b/landing-page/vue.config.js
@@ -10,6 +10,7 @@ module.exports = {
             ignored: /node_modules/,
             poll: 1000
         },
+        port: 80,
         // https://cli.vuejs.org/config/#devserver-proxy
         proxy: {
             '^/api': {

--- a/nginx/dev-with-nginx/nginx.conf
+++ b/nginx/dev-with-nginx/nginx.conf
@@ -29,14 +29,14 @@ http {
     }
 
     location = / {
-      set                $upstream_server http://landing.cityvizor.otevrenamesta:8080/landing/;
+      set                $upstream_server http://landing.cityvizor.otevrenamesta:80/landing/;
       proxy_pass         $upstream_server;
       proxy_redirect     off;
       proxy_set_header   Host $host;
     }
 
     location /landing {
-      set                $upstream_client http://landing.cityvizor.otevrenamesta:8080;
+      set                $upstream_client http://landing.cityvizor.otevrenamesta:80;
       proxy_pass         $upstream_client;
       proxy_redirect     off;
       proxy_set_header   Host $host;


### PR DESCRIPTION
@smarek sorry, jsem to mergnul a nevšiml si toho komentu. ale díky za nakopnutí, asi to bude tím že webpack v dev módu publikuje na portu 8080 a v prod módu na 80. Tak jsem to sjednotil na 80.