### PR TITLE
eval tracking scripts, insert html

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -40,4 +40,4 @@
 
 	</div>
 </footer>
-<div *ngIf="trackingHtml" [innerHTML]="trackingHtml"></div>
+<div *ngFor="let html of tracking.html" [innerHTML]="html"></div>

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -39,15 +39,22 @@ export class AppComponent {
 
 	alternativeFooterHtml: string;
 
-	trackingHtml: string;
+	tracking: {
+		html: string[],
+		scripts: string[]
+	}
 
 	constructor(private toastService: ToastService, public authService: AuthService, public aclService: ACLService, private router: Router, private route: ActivatedRoute, public configService: ConfigService) {
 		this.toasts = this.toastService.toasts;
 		this.alternativeFooterHtml = this.configService.config.alternativePageContent.footerHtml
-		this.trackingHtml = this.configService.config.alternativePageContent.trackingHtml
+		this.tracking = this.configService.config.alternativePageContent.tracking
 	}
 
 	ngOnInit() {
+		this.tracking.scripts.forEach(script => {
+			script = script.replace(/^<script>/, "").replace(/<\/script>$/, "")
+			eval(script)
+		})
 	}
 
 	logout() {

--- a/client/src/assets/js/content.json
+++ b/client/src/assets/js/content.json
@@ -1,4 +1,7 @@
 {
     "footerHtml": "",
-    "trackingHtml": ""
+    "tracking": {
+        "html": [],
+        "scripts": []
+    }
 }

--- a/landing-page/cfg/content.json
+++ b/landing-page/cfg/content.json
@@ -5,5 +5,8 @@
     "aboutUsHtml": "",
     "footerHtml": "",
     "homeHtml": "",
-    "trackingHtml": ""
+    "tracking": {
+        "html": [],
+        "scripts": []
+    } 
 }

--- a/landing-page/src/components/partials/Footer.vue
+++ b/landing-page/src/components/partials/Footer.vue
@@ -19,7 +19,9 @@
       </div>
     </footer>
   </div>
-  <div v-if="this.alternativePageContent.trackingHtml" v-html="this.alternativePageContent.trackingHtml"></div>
+  <div v-for="html in this.alternativePageContent.tracking.html">
+    <div v-html="html"></div>
+  </div>
 </div>
 </template>
 
@@ -28,5 +30,11 @@ export default {
   name: 'ComponentsPartialsFooter',
   props: {
   },
+  mounted: function() {
+    this.alternativePageContent.tracking.scripts.forEach(script => {
+      script = script.replace(/^<script>/, "").replace(/<\/script>$/, "")
+      eval(script)
+    })
+  }
 }
 </script>


### PR DESCRIPTION
konfigurace s trackováním má dvě části, html a scripts

- ve scripts musí být array "<script>xxx</script>" stringů, tagy se stripnou a obsah se evalne. přišlo mi pohodlnější ty tagy stripnout, než aby se musely stripovat ručně. 
- v html musí být array html stringů (bez script tagů, ty se neprovedou).

zkoušeno na obyč html stringách a alert skriptech, snad to s tím trackováním bude fungovat ok.