### PR TITLE
Feature/fix importing

### DIFF
--- a/server/src/worker/import/cityvizor/parser.ts
+++ b/server/src/worker/import/cityvizor/parser.ts
@@ -114,7 +114,7 @@ function createDataTransformer(options: Import.Options) {
       } catch (err) {
         callback(err);
       }
-      callback()
+      callback();
     },
   });
 }

--- a/server/src/worker/import/cityvizor/parser.ts
+++ b/server/src/worker/import/cityvizor/parser.ts
@@ -103,19 +103,18 @@ function createDataTransformer(options: Import.Options) {
     transform(line, enc, callback) {
       const recordType = line.type;
 
-      if (recordType === 'KDF' || recordType === 'KOF') {
-        try {
-          const payment = createPaymentRecord(line, options);
-          this.push({type: 'payment', record: payment});
-          callback();
-        } catch (err) {
-          callback(err);
-        }
-      } else {
+      try {
         const accounting = createAccountingRecord(line, options);
         this.push({type: 'accounting', record: accounting});
-        callback();
+        // TODO: Why does the paymentRecord have to be pushed twice, once as payment and once as accounting?
+        if (recordType === 'KDF' || recordType === 'KOF') {
+          const payment = createPaymentRecord(line, options);
+          this.push({type: 'payment', record: payment});
+        }
+      } catch (err) {
+        callback(err);
       }
+      callback()
     },
   });
 }

--- a/server/src/worker/import/import.ts
+++ b/server/src/worker/import/import.ts
@@ -28,6 +28,7 @@ export namespace Import {
     transaction: Transaction;
     importDir: string;
     append: boolean;
+    fileName?: string;
   }
 
   export type ImportChunk = PaymentChunk | EventChunk | AccountingChunk;

--- a/server/src/worker/import/internetstream/importer.ts
+++ b/server/src/worker/import/internetstream/importer.ts
@@ -88,6 +88,18 @@ function createTransformer(options: Import.Options) {
       const amountFinal =
         item < 5000 ? amountMd - amountDal : amountDal - amountMd;
 
+        const accounting: AccountingRecord = {
+          type: recordType,
+          paragraph: line.PARAGRAF,
+          item,
+          event: line.ORGANIZACE,
+          unit: line.ORJ,
+          amount: amountFinal,
+
+          profileId: options.profileId,
+          year: options.year,
+        };
+      this.push({type: 'accounting', record: accounting});
       if (recordType === 'KDF' || recordType === 'KOF') {
         const payment: PaymentRecord = {
           paragraph: line.PARAGRAF,
@@ -103,22 +115,8 @@ function createTransformer(options: Import.Options) {
           year: options.year,
         };
         this.push({type: 'payment', record: payment});
-        callback();
-      } else {
-        const accounting: AccountingRecord = {
-          type: recordType,
-          paragraph: line.PARAGRAF,
-          item,
-          event: line.ORGANIZACE,
-          unit: line.ORJ,
-          amount: amountFinal,
-
-          profileId: options.profileId,
-          year: options.year,
-        };
-        this.push({type: 'accounting', record: accounting});
-        callback();
-      }
+      } 
+      callback();
     },
   });
 }

--- a/server/src/worker/import/internetstream/importer.ts
+++ b/server/src/worker/import/internetstream/importer.ts
@@ -23,6 +23,7 @@ export async function importInternetStream(options: Import.Options) {
     path.join(options.importDir, 'SK.csv'),
   ];
   for (const p of csvPaths) {
+    options.fileName = p;
     const fileReader = fs.createReadStream(p);
     const isParser = createParser();
     const isTransformer = createTransformer(options);
@@ -81,24 +82,27 @@ function createTransformer(options: Import.Options) {
     writableObjectMode: true,
     readableObjectMode: true,
     transform(line, enc, callback) {
-      const recordType = line.DOKLAD_AGENDA;
+      // RU.csv contains "upraveny rozpocet" records, but they do not have "ROZ" type
+      const recordType = options.fileName?.endsWith('RU.csv')
+        ? 'ROZ'
+        : line.DOKLAD_AGENDA;
       const amountMd = line.CASTKA_MD;
       const amountDal = line.CASTKA_DAL;
       const item = Number(line.POLOZKA);
       const amountFinal =
         item < 5000 ? amountMd - amountDal : amountDal - amountMd;
 
-        const accounting: AccountingRecord = {
-          type: recordType,
-          paragraph: line.PARAGRAF,
-          item,
-          event: line.ORGANIZACE,
-          unit: line.ORJ,
-          amount: amountFinal,
+      const accounting: AccountingRecord = {
+        type: recordType,
+        paragraph: line.PARAGRAF,
+        item,
+        event: line.ORGANIZACE,
+        unit: line.ORJ,
+        amount: amountFinal,
 
-          profileId: options.profileId,
-          year: options.year,
-        };
+        profileId: options.profileId,
+        year: options.year,
+      };
       this.push({type: 'accounting', record: accounting});
       if (recordType === 'KDF' || recordType === 'KOF') {
         const payment: PaymentRecord = {
@@ -115,7 +119,7 @@ function createTransformer(options: Import.Options) {
           year: options.year,
         };
         this.push({type: 'payment', record: payment});
-      } 
+      }
       callback();
     },
   });


### PR DESCRIPTION
Faktury je potřeba vkládat do db dvakrát, jednou jako rozpočet a jednou jako faktura. Nejspíš nějaký důsledek architektury.
Martin Šebek: "Jde podle mě o strukturu db a mám dojem, že po nějaké době se to rozhodilo a ještě na P1 jsme s Kopcem naživo analyzovali. Jen jsem si nepamatoval, jestli to bylo plus nebo minus (mám dojem , ze jeden stav i byl, že se nám faktury v čerpání násobičky a ručně jsem je ve vstupních datech dával s mínusem, než to Kopec upravil)"

Internetstream má data o upraveném rozpočtu v souboru `RU.csv`, ale záznamy nemají typ `ROZ`, je potřeba je i tak brát jako rozpočet.