### PR TITLE
Allow user to wait for arbitrary TCP connection to become available in

### DIFF
--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-wait_for_db=''
+wait_for_host=''
 set_admin=''
 mode=''
 do_install=''
 
 print_usage() {
-  printf "Usage: -w (wait for database to respond) <DB_ADDRESS> \
+  printf "Usage: -w (wait for database to respond) <TARGET_ADDRESS:TARGET_PORT> \
   -a (set default administrator account with admin/admin credentials) \
   -m (set the command executed by npm) \
   -i (install npm dependencies before running anything else)"
@@ -14,7 +14,7 @@ print_usage() {
 
 while getopts 'w:am:i' flag; do
   case "${flag}" in
-    w) wait_for_db="${OPTARG}" ;;
+    w) wait_for_host="${OPTARG}" ;;
     a) set_admin='true' ;;
     m) mode="${OPTARG}" ;;
     i) do_install='true' ;;
@@ -27,8 +27,8 @@ if [[ ! -z "$do_install" ]]; then
     npm install
 fi
 
-if [[ ! -z "$wait_for_db" ]]; then
-    bash src/scripts/wait-for-it.sh -h "$wait_for_db" -p 5432
+if [[ ! -z "$wait_for_host" ]]; then
+    bash src/scripts/wait-for-it.sh "$wait_for_host"
 fi
 
 npm run migrate:latest


### PR DESCRIPTION
Allow user to wait for arbitrary TCP connection to become available in docker enterypoint.sh command parameter.

Signed-off-by: Daniel Staněk <stanek.daniel@operatorict.cz>