### PR TITLE
Disable caching of authenticated requests

### DIFF
--- a/server/src/routers/index.ts
+++ b/server/src/routers/index.ts
@@ -15,6 +15,8 @@ const cache = getExpeditiousCache({
       port: config.redis.port,
     },
   }),
+  // Don't cache requests of logged in users to avoid leaking protected data via cache
+  shouldCache: req => !req?.user,
 });
 
 export const Routers = router;


### PR DESCRIPTION
https://github.com/cityvizor/cityvizor/pull/457 přidalo access control logiku podle kombinace vlastností profilu a přistupujícího uživatele (tj. takovou, která nejde podchytit jen kombinací route + role). Problém, ale je, že jsou public cesty bez rozdílu cachovány a cache middleware obchází danou autorizační logiku. Aby nemuselo být přepisováno mnohem víc kódu, vypínam prostě cachování dotazů pro přihlášené uživatele. To nebude mít negativní dopad na výkon aplikace, protože takových uživatelů (adminů) je málo a negenerují velkou zátěž. Zároveň je pro adminy lepší, když dostávájí necachovaný obsah.