### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish-docker-client.yml
+++ b/.github/workflows/publish-docker-client.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v3.x
       - name: Publish landing-page to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cityvizor/cityvizor-client
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/publish-docker-demo.yml
+++ b/.github/workflows/publish-docker-demo.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v3.x
       - name: Publish landing-page to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cityvizor/cityvizor-demo
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/publish-docker-landing-page.yml
+++ b/.github/workflows/publish-docker-landing-page.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v3.x
       - name: Publish landing-page to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cityvizor/landing-page
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/publish-docker-server.yml
+++ b/.github/workflows/publish-docker-server.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v3.x
       - name: Publish server to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cityvizor/cityvizor-server
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore