### PR TITLE
#543 Add DB view for PBO payments to fix income/expenditure split

### DIFF
--- a/server/migrations/20230405140000_add_pbo_payments_view.js
+++ b/server/migrations/20230405140000_add_pbo_payments_view.js
@@ -1,0 +1,32 @@
+exports.up = async function (knex) {
+  return await knex.schema.raw(`
+  CREATE OR REPLACE VIEW public.pbo_payments AS
+  SELECT
+    payments.profile_id,
+    payments.year,
+    payments.paragraph,
+    payments.item,
+    payments.event,
+    CASE
+        WHEN payments.item >= 600
+            AND payments.item < 700 THEN payments.amount
+        ELSE 0::numeric
+    END AS income_amount,
+    CASE
+        WHEN payments.item >= 500
+            AND payments.item < 600 THEN payments.amount
+        ELSE 0::numeric
+    END AS expenditure_amount,
+    payments.date,
+    payments.counterparty_id,
+    payments.counterparty_name,
+    payments.description
+  FROM data.payments payments
+  JOIN years y ON y.year = payments.year
+  AND y.profile_id = payments.profile_id
+  `);
+};
+
+exports.down = async function (knex) {
+  return await knex.schema.raw('DROP VIEW public.pbo_payments');
+};

--- a/server/src/routers/public/profile-payments.ts
+++ b/server/src/routers/public/profile-payments.ts
@@ -1,14 +1,29 @@
 import express from 'express';
 
 import {db, getValidDateString, isValidDateString, sort2order} from '../../db';
-import {PaymentRecord, EventRecord} from '../../schema';
+import {PaymentRecord, EventRecord, ProfileRecord} from '../../schema';
 
 const router = express.Router({mergeParams: true});
 
 export const ProfilePaymentsRouter = router;
 
 router.get('/', async (req, res) => {
-  const payments = await db<PaymentRecord>('payments')
+  // const profileType = await db<ProfileRecord>('profiles');
+
+  const profile = await db<ProfileRecord>('app.profiles')
+    .where({id: Number(req.params.profile)})
+    .first()
+    .then(row => row);
+
+  if (!profile) {
+    res.sendStatus(404);
+    return;
+  }
+
+  const view =
+    profile.type === 'pbo' ? 'public.pbo_payments' : 'public.payments';
+
+  const payments = await db<PaymentRecord>(view)
     .where('profile_id', req.params.profile)
     .limit(req.query.limit ? Math.min(Number(req.query.limit), 10000) : 10000)
     .offset(Number(req.query.offset || 0))

--- a/server/src/routers/public/profile-plans.ts
+++ b/server/src/routers/public/profile-plans.ts
@@ -16,8 +16,7 @@ router.get('/', async (req, res) => {
     .where('profile_id', req.params.profile)
     .groupBy('year', 'profileId');
 
-  if (years.length) res.json(years);
-  else res.sendStatus(404);
+  res.json(years);
 });
 
 router.get('/:year', async (req, res) => {

--- a/server/src/schema/database/payment.ts
+++ b/server/src/schema/database/payment.ts
@@ -2,7 +2,7 @@ export interface PaymentRecord {
   profileId: number;
   year: number;
 
-  paragraph: number;
+  paragraph?: number;
   item: number;
   unit?: number;
   event?: number;


### PR DESCRIPTION
Přidává view `public.pbo_payments`, které používá narozdíl od `public.payments` jiné intervaly pro určování z hodnoty `item`, které položky jsou náklady a které příjmy.