### PR TITLE
#543 Fix PBO income/expenditure labels

### DIFF
--- a/client/src/app/shared/components/event-detail/event-detail.component.html
+++ b/client/src/app/shared/components/event-detail/event-detail.component.html
@@ -34,7 +34,7 @@
 				</ng-template>
 			</div>
 
-			<h3>{{'profile.municipality.income' | translate}}</h3>
+			<h3>{{'profile.municipality.incomes' | translate}}</h3>
 			<div class="overview">
 
 				<ng-container *ngIf="event.incomeAmount || event.budgetIncomeAmount; else noIncome">
@@ -79,7 +79,7 @@
 									<td>{{'profile.municipality.expenditures' | translate}}</td>
 								</tr>
 								<tr style="height:60px;">
-									<td>{{'profile.municipality.income' | translate}}</td>
+									<td>{{'profile.municipality.incomes' | translate}}</td>
 								</tr>
 							</thead>
 						</table>
@@ -164,8 +164,12 @@
 									<table class="table table-responsive small table-label-date-title-number table-nobottommargin">
 										<tr *ngFor="let payment of counterparty.payments">
 											<td>
-												<span *ngIf="payment.incomeAmount - payment.expenditureAmount > 0" class="label label-success">Příjem</span>
-												<span *ngIf="payment.incomeAmount - payment.expenditureAmount < 0" class="label label-red">Výdaj</span>
+												<span *ngIf="payment.incomeAmount - payment.expenditureAmount > 0" class="label label-success">
+													{{ 'profile.' + profile.type + '.income' | translate }}
+												</span>
+												<span *ngIf="payment.incomeAmount - payment.expenditureAmount < 0" class="label label-red">
+													{{ 'profile.' + profile.type + '.expenditure' | translate }}
+												</span>
 												&nbsp;
 												<span class="small text-muted" [title]="paragraphNames[payment.paragraph] || ''">§{{payment.paragraph}}</span>
 												&nbsp;
@@ -314,7 +318,7 @@
 								<th class="text-right">
 									{{ isMunicipality ? 'Rozpočtovaná částka' : 'Plánovaná částka' }}									
 								</th>
-								<th class="text-right">Skutečný příjem</th>
+								<th class="text-right">{{ 'profile.' + profile.type + '.realIncome' | translate }}</th>
 							</tr>
 						</thead>
 						<tbody>

--- a/client/src/app/views/profile/profile.component.html
+++ b/client/src/app/views/profile/profile.component.html
@@ -10,7 +10,7 @@
 			</li>
 			<li>
 				<a routerLink="hospodareni/prijmy" routerLinkActive="active">
-					{{ 'profile.municipality.income' | translate }}
+					{{ 'profile.municipality.incomes' | translate }}
 				</a>
 			</li>
 			<li><a routerLink="faktury" routerLinkActive="active">Faktury</a></li>
@@ -37,7 +37,7 @@
 			</li>
 			<li>
 				<a routerLink="hospodareni/prijmy" routerLinkActive="active">
-					{{ 'profile.pbo.income' | translate }}
+					{{ 'profile.pbo.incomes' | translate }}
 				</a>
 			</li>
 			<li>

--- a/client/src/app/views/profile/views/profile-dashboard/profile-dashboard.component.html
+++ b/client/src/app/views/profile/views/profile-dashboard/profile-dashboard.component.html
@@ -167,7 +167,7 @@
 								<chart-budget [data]="budget" [type]="'income'" [max]="maxBudgetAmount"
 									(click)="openBudget($event,budget.year)"></chart-budget>
 								<span class="label label-blue" (click)="openBudget($event,budget.year)">
-									{{ 'profile.' + profile.type + '.income' | translate }}
+									{{ 'profile.' + profile.type + '.incomes' | translate }}
 								</span>
 							</th>
 						</tr>

--- a/client/src/app/views/profile/views/profile-invoices/profile-invoices.component.html
+++ b/client/src/app/views/profile/views/profile-invoices/profile-invoices.component.html
@@ -18,8 +18,12 @@
 			<tbody>
 				<tr *ngFor="let invoice of invoices">
 					<td>
-							<span *ngIf="invoice.expenditureAmount > invoice.incomeAmount" class="label label-red">Výdaj</span>
-							<span *ngIf="invoice.expenditureAmount < invoice.incomeAmount" class="label label-success">Příjem</span>
+						<span *ngIf="invoice.expenditureAmount > invoice.incomeAmount" class="label label-red">
+              {{ 'profile.' + profileType + '.expenditure' | translate }}
+            </span>
+						<span *ngIf="invoice.expenditureAmount < invoice.incomeAmount" class="label label-success">
+              {{ 'profile.' + profileType + '.income' | translate }}
+            </span>
 					</td>
 					<td>{{invoice.date | date:"d. M. y"}}</td>
 					<td class="small text-muted"><ng-container *ngIf="invoice.paragraph">§{{invoice.paragraph}}</ng-container></td>

--- a/client/src/app/views/profile/views/profile-invoices/profile-invoices.component.ts
+++ b/client/src/app/views/profile/views/profile-invoices/profile-invoices.component.ts
@@ -3,7 +3,7 @@ import { Router, ActivatedRoute, Params } from '@angular/router';
 import { Observable, combineLatest } from 'rxjs';
 import { DataService } from 'app/services/data.service';
 import { ProfileService } from 'app/services/profile.service';
-import { Profile } from 'app/schema';
+import { Profile, ProfileType } from 'app/schema';
 import { DateTime } from 'luxon';
 
 @Component({
@@ -21,6 +21,8 @@ export class ProfileInvoicesComponent implements OnInit {
 	invoices: any[] = [];
 	loading: boolean = false;
 
+	profileType: ProfileType = "municipality";
+
 	constructor(private dataService: DataService, private profileService: ProfileService, private route: ActivatedRoute, private router: Router) { }
 
 	ngOnInit() {
@@ -31,8 +33,9 @@ export class ProfileInvoicesComponent implements OnInit {
 		combineLatest(this.profile, this.params)
 			.subscribe(([profile, params]) => {
 				if (!profile) return;
-				let year = Number(params["rok"]);
-				let month = Number(params["mesic"]);
+				this.profileType = profile.type;
+				const year = Number(params["rok"]);
+				const month = Number(params["mesic"]);
 				if (year) this.loadData(profile.id, year, month);
 			});
 	}

--- a/client/src/assets/text/cs.json
+++ b/client/src/assets/text/cs.json
@@ -14,15 +14,21 @@
             "budget": "Rozpočet",
             "actual": "Skutečnost",
             "utilization": "Plnění",
+            "expenditure": "Výdaj",
             "expenditures": "Výdaje",
-            "income": "Příjmy"
+            "income": "Příjem",
+            "incomes": "Příjmy",
+            "realIncome": "Skutečný příjem"
         },
         "pbo": {
             "budget": "Plán",
             "actual": "Skutečnost",
             "plan": "Plán",
+            "expenditure": "Náklad",
             "expenditures": "Náklady",
-            "income": "Výnosy"
+            "income": "Výnos",
+            "incomes": "Výnosy",
+            "realIncome": "Skutečný výnos"
         },
         "import": {
             "replaceOrAdd": "Nahradit nebo přidat data?"


### PR DESCRIPTION
Přejmenovává několik výskytů příjem/výdej na výnos/náklad pro příspěvkovky. Používá `translate` pipe z ngx-translate.