### PR TITLE
Nastavení kategorie příspěvkové organizace v Administraci

### DIFF
--- a/client/src/app/schema/pbo-category.ts
+++ b/client/src/app/schema/pbo-category.ts
@@ -1,0 +1,4 @@
+export interface PboCategory {
+    pboCategoryId: number;
+    pboCategoryCsName: string;
+}

--- a/client/src/app/schema/pbo-category.ts
+++ b/client/src/app/schema/pbo-category.ts
@@ -1,4 +1,5 @@
 export interface PboCategory {
     pboCategoryId: number;
     pboCategoryCsName: string;
+    pboCategoryEnName: string;
 }

--- a/client/src/app/schema/profile.ts
+++ b/client/src/app/schema/profile.ts
@@ -10,6 +10,7 @@ export class Profile {
     status: ProfileStatus;
     sumMode: ProfileSumMode;
     type: ProfileType;
+    pboCategoryId?: number | null;
 
     main: boolean;
 

--- a/client/src/app/services/admin.service.ts
+++ b/client/src/app/services/admin.service.ts
@@ -4,6 +4,7 @@ import { HttpClient, HttpResponse } from '@angular/common/http';
 import { environment } from "environments/environment";
 import { Profile, BudgetYear, User } from 'app/schema';
 import { Import } from 'app/schema/import';
+import { PboCategory } from 'app/schema/pbo-category';
 
 @Injectable({
   providedIn: 'root'
@@ -108,5 +109,10 @@ export class AdminService {
   }
   deleteUser(userId: User["id"]) {
     return this.http.delete(this.root + "/users/" + userId, { responseType: 'text' }).toPromise();
+  }
+
+  /* OPTIONS */
+  getPboCategories(): Promise<PboCategory[]> {
+    return this.http.get<PboCategory[]>(this.root + "/pbo-categories").toPromise();
   }
 }

--- a/client/src/app/views/admin/views/admin-profile/admin-profile-settings/admin-profile-settings.component.html
+++ b/client/src/app/views/admin/views/admin-profile/admin-profile-settings/admin-profile-settings.component.html
@@ -6,7 +6,8 @@
     <form class="form" #settingsForm="ngForm" (ngSubmit)="saveProfile(settingsForm)">
       <div class="form-group">
         <label>Typ profilu</label>
-        <select name="type" [ngModel]="profile?.type" (ngModelChange)="onProfileTypeChange($event)" class="form-control">
+        <select name="type" [ngModel]="profile?.type" (ngModelChange)="onProfileTypeChange($event)"
+          class="form-control">
           <option value="municipality">Municipalita (město / kraj)</option>
           <option value="pbo">Příspěvková organizace</option>
           <option value="external">Externí profil</option>
@@ -16,7 +17,6 @@
       <div *ngIf="profile?.type === 'pbo'" class="form-group">
         <label>Kategorie příspěvkové organizace</label>
         <select name="pboCategoryId" [ngModel]="profile?.pboCategoryId" class="form-control">
-          <option value="null" [selected]="profile?.pboCategoryId == null">Nezařazeno</option>
           <option *ngFor="let c of pboCategories" [value]="c.pboCategoryId"
             [selected]="c.pboCategoryId === profile?.pboCategoryId">
             {{c.pboCategoryCsName}}
@@ -63,7 +63,7 @@
         <label>Rodičovský profil</label>
         <select name="parent" [ngModel]="profile?.parent" class="form-control">
           <option value="null" [selected]="profile?.parent == null">žádný</option>
-          <option *ngFor="let p of profiles" [value]="p.id" [selected]="p.id === profile?.parent">
+          <option *ngFor="let p of profilesValidAsParent" [value]="p.id" [selected]="p.id === profile?.parent">
             {{p.name}}
           </option>
         </select>
@@ -88,7 +88,7 @@
         <label><input type="checkbox" name="main" [value]="true" [ngModel]="profile?.main">&nbsp;Hlavní profil</label>
       </div>
 
-      <button type="submit" class="btn btn-primary" [disabled]="!settingsForm.valid">{{'common.save' |
+      <button type="submit" class="btn btn-primary" style="margin-bottom: 2em;" [disabled]="!settingsForm.valid">{{'common.save' |
         translate}}</button>
 
     </form>

--- a/client/src/app/views/admin/views/admin-profile/admin-profile-settings/admin-profile-settings.component.html
+++ b/client/src/app/views/admin/views/admin-profile/admin-profile-settings/admin-profile-settings.component.html
@@ -1,14 +1,26 @@
 <div class="row">
   <div class="col-md-7">
     <h3>Základní informace</h3>
+    {{ profile | json }}
+
     <form class="form" #settingsForm="ngForm" (ngSubmit)="saveProfile(settingsForm)">
       <div class="form-group">
         <label>Typ profilu</label>
-        <select name="type" [ngModel]="profile?.type" class="form-control">
-          <option value="municipality">Municipalita (město)</option>
+        <select name="type" [ngModel]="profile?.type" (ngModelChange)="onProfileTypeChange($event)" class="form-control">
+          <option value="municipality">Municipalita (město / kraj)</option>
           <option value="pbo">Příspěvková organizace</option>
           <option value="external">Externí profil</option>
           <option value="empty">Profil bez rozpočtu</option>
+        </select>
+      </div>
+      <div *ngIf="profile?.type === 'pbo'" class="form-group">
+        <label>Kategorie příspěvkové organizace</label>
+        <select name="pboCategoryId" [ngModel]="profile?.pboCategoryId" class="form-control">
+          <option value="null" [selected]="profile?.pboCategoryId == null">Nezařazeno</option>
+          <option *ngFor="let c of pboCategories" [value]="c.pboCategoryId"
+            [selected]="c.pboCategoryId === profile?.pboCategoryId">
+            {{c.pboCategoryCsName}}
+          </option>
         </select>
       </div>
       <div class="form-group">
@@ -50,7 +62,7 @@
       <div class="form-group">
         <label>Rodičovský profil</label>
         <select name="parent" [ngModel]="profile?.parent" class="form-control">
-          <option value="null" selected="p.id == null">žádný</option>
+          <option value="null" [selected]="profile?.parent == null">žádný</option>
           <option *ngFor="let p of profiles" [value]="p.id" [selected]="p.id === profile?.parent">
             {{p.name}}
           </option>
@@ -76,7 +88,8 @@
         <label><input type="checkbox" name="main" [value]="true" [ngModel]="profile?.main">&nbsp;Hlavní profil</label>
       </div>
 
-      <button type="submit" class="btn btn-primary" [disabled]="!settingsForm.valid">{{'common.save' | translate}}</button>
+      <button type="submit" class="btn btn-primary" [disabled]="!settingsForm.valid">{{'common.save' |
+        translate}}</button>
 
     </form>
   </div>
@@ -94,7 +107,8 @@
         <div class="input-group">
           <input type="file" name="avatar" class="form-control" #avatarFileInput>
           <div class="input-group-btn">
-            <button type="submit" (click)="uploadAvatar(avatarFileInput)" class="btn btn-primary">{{'common.upload' | translate}}</button>
+            <button type="submit" (click)="uploadAvatar(avatarFileInput)" class="btn btn-primary">{{'common.upload' |
+              translate}}</button>
           </div>
         </div>
       </div>

--- a/client/src/app/views/admin/views/admin-profile/admin-profile-settings/admin-profile-settings.component.ts
+++ b/client/src/app/views/admin/views/admin-profile/admin-profile-settings/admin-profile-settings.component.ts
@@ -8,6 +8,7 @@ import { Router } from '@angular/router';
 import { ConfigService } from 'config/config';
 import { ToastService } from 'app/services/toast.service';
 import { DataService } from 'app/services/data.service';
+import { PboCategory } from 'app/schema/pbo-category';
 
 @Component({
   selector: 'admin-profile-settings',
@@ -15,12 +16,11 @@ import { DataService } from 'app/services/data.service';
   styleUrls: ['./admin-profile-settings.component.scss']
 })
 export class AdminProfileSettingsComponent implements OnInit {
-
   profileId: Observable<number | null>;
-
   profile: Profile;
   profiles: Profile[];
   parentProfileName?: string;
+  pboCategories: PboCategory[];
 
   constructor(
     private profileService: ProfileService,
@@ -31,11 +31,11 @@ export class AdminProfileSettingsComponent implements OnInit {
     public configService: ConfigService
   ) { }
 
-  async ngOnInit () {
+  async ngOnInit() {
     this.profileId = this.profileService.profileId;
     this.profiles = await this.dataService.getProfiles();
     this.profileId.subscribe(profileId => {
-      if(profileId) this.loadProfile(profileId)
+      if (profileId) this.loadProfile(profileId)
     });
   }
 
@@ -43,19 +43,21 @@ export class AdminProfileSettingsComponent implements OnInit {
     this.profile = await this.adminService.getProfile(profileId);
   }
 
-  async reloadProfile(){
+  async reloadProfile() {
     this.profile = await this.adminService.getProfile(this.profile.id);
     this.profileService.setProfile(this.profile);
   }
 
   async saveProfile(form: NgForm) {
     const data = form.value;
-    if(data.parent == "null") data.parent = null;
+    
+    if (data.parent == "null") data.parent = null;
+    
     await this.adminService.saveProfile(this.profile.id, data)
+    
     this.reloadProfile();
 
     this.toastService.toast("Uloženo.", "notice")
-
   }
 
   async uploadAvatar(fileInput: HTMLInputElement) {
@@ -97,4 +99,9 @@ export class AdminProfileSettingsComponent implements OnInit {
     return this.profiles.find(p => p.id === this.profile.parent)?.name;
   }
 
+  onProfileTypeChange(newValue: ProfileType) {
+    if (this.profile) {
+      this.profile.type = newValue;
+    }
+  }
 }

--- a/server/src/config/roles.ts
+++ b/server/src/config/roles.ts
@@ -53,6 +53,8 @@ export const aclRoles = {
       'users:list': true,
       'users:read': true,
       'users:write': true,
+      'options:read': true,
+      "options:write": true,
     },
   },
 
@@ -73,6 +75,8 @@ export const aclRoles = {
       'profile-imports:list': true,
       'profile-accounting:list': true,
       'profile-accounting:write': req => isManagedProfile(req),
+      'options:read': true,
+      "options:write": false,
     },
   },
 };

--- a/server/src/routers/admin/index.ts
+++ b/server/src/routers/admin/index.ts
@@ -5,6 +5,7 @@ import {AdminProfilesRouter} from './profiles';
 import {AdminUsersRouter} from './users';
 import {AdminProfileImportTokenRouter} from './profile-import-token';
 import {AdminProfileImportsRouter} from './profile-imports';
+import { PboCategoriesRouter } from './pbo-categories';
 
 const router = express.Router();
 
@@ -22,4 +23,8 @@ router.use('/profiles/:profile/imports', AdminProfileImportsRouter);
 /* USERS */
 router.use('/users', AdminUsersRouter);
 
+/* SETTINGS OPTIONS */
+router.use('/pbo-categories', PboCategoriesRouter);
+
+/* FALLBACK */
 router.use('**', (req, res) => res.sendStatus(404));

--- a/server/src/routers/admin/pbo-categories.ts
+++ b/server/src/routers/admin/pbo-categories.ts
@@ -1,0 +1,77 @@
+import express, { Request, Response } from "express";
+import acl from 'express-dynacl';
+import { db } from "../../db";
+import { PboCategoryRecord } from "../../schema/database/pbo-category";
+
+const router = express.Router();
+
+export const PboCategoriesRouter = router;
+
+// LIST
+router.get('/', acl('options:read'), async (req: Request, res: Response) => {
+  try {
+    const data = await db<PboCategoryRecord>('app.pbo_categories');
+
+    res.json(data ?? []);
+  } catch (err) {
+    res.status(500).json({ error: err instanceof Error ? err.message : err });
+  }
+});
+
+// READ
+router.get('/:id', acl('options:read'), async (req: Request<{ id: string }>, res: Response) => {
+  try {
+    const data = await db<PboCategoryRecord>('app.pbo_categories')
+      .where('pboCategoryId', req.params.id)
+      .first();
+
+    if (data) {
+      res.json(data);
+    } else {
+      res.sendStatus(404);
+    }
+  } catch (err) {
+    res.status(500).json({ error: err instanceof Error ? err.message : err });
+  }
+});
+
+// CREATE
+router.post('/', acl('options:write'), async (req: Request, res: Response) => {
+  try {
+    const body: Omit<PboCategoryRecord, "pboCategoryId"> = req.body;
+
+    const [id] = await db('app.pbo_categories').insert(body, ['pboCategoryId']);
+
+    res.status(201).json(id);
+  } catch (err) {
+    res.status(500).json({ error: err instanceof Error ? err.message : err });
+  }
+});
+
+// UPDATE
+router.put('/:id', acl('options:write'), async (req: Request<{ id: string }>, res: Response) => {
+  try {
+    const body: Partial<PboCategoryRecord> = req.body;
+
+    await db('app.pbo_categories')
+      .where('pboCategoryId', req.params.id)
+      .update(body);
+
+    res.sendStatus(200);
+  } catch (err) {
+    res.status(500).json({ error: err instanceof Error ? err.message : err });
+  }
+});
+
+// DELETE
+router.delete('/:id', acl('options:write'), async (req: Request<{ id: string }>, res: Response) => {
+  try {
+    await db('app.pbo_categories')
+      .where({ pboCategoryId: req.params.id })
+      .delete();
+
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(500).json({ error: err instanceof Error ? err.message : err });
+  }
+});

--- a/server/src/schema/database/pbo-category.ts
+++ b/server/src/schema/database/pbo-category.ts
@@ -1,0 +1,5 @@
+export interface PboCategoryRecord {
+    pboCategoryId: number;
+    pboCategoryCsName: string;
+    pboCategoryEnName: string;
+}


### PR DESCRIPTION
- Přidává API router do Serveru pro správu kategorií PBO v DB, vyžaduje autorizaci Admin rolí
- Přidává dropdown pro výběr kategorie PBO v Administraci profilu
- Přidává filtraci profilů, které lze nastavit jako rodiče jiného profilu
  - nejde nastavit profil, co už je sám potomkem
  - nejde nastavit sebe
  - asi by nemelo jit pro municipalitu nastavit jako rodice PBO, ale to ted neresim