### PR TITLE
Validace odesílatele formuláře

### DIFF
--- a/server/src/routers/public/feedback.ts
+++ b/server/src/routers/public/feedback.ts
@@ -82,18 +82,23 @@ Informace o propojení: ${req.body.subscribe}
 );
 
 async function sendToEmail(type: string, content: string) {
+  const senderAddress = environment.email.user?.trim();
+  if (!senderAddress) {
+    throw new Error("Cannot send feedback: EMAIL_USER is not configured");
+  }
+
   const transporter = nodemailer.createTransport({
     host: environment.email.smtp,
     port: Number(environment.email.port),
     secure: Number(environment.email.port) === 465, // true for 465, false for other ports
     auth: {
-      user: environment.email.user,
+      user: senderAddress,
       pass: environment.email.password,
     },
   });
 
   const info = await transporter.sendMail({
-    from: `"Cityvizor feedback" <${environment.email.user}>`,
+    from: `"Cityvizor feedback" <${senderAddress}>`,
     to: environment.email.address,
     subject: type,
     text: content,

--- a/server/test/feedback.test.ts
+++ b/server/test/feedback.test.ts
@@ -1,0 +1,88 @@
+import { FeedbackRouter } from "../src/routers/public/feedback";
+import environment from "../environment";
+import nodemailer from "nodemailer";
+
+jest.mock("../environment", () => ({
+  email: {
+    address: "office@cityvizor.test",
+    smtp: "smtp.cityvizor.test",
+    port: "587",
+    user: "feedback@cityvizor.test",
+    password: "test-password",
+  },
+}));
+
+jest.mock("nodemailer", () => ({
+  __esModule: true,
+  default: {
+    createTransport: jest.fn(),
+  },
+}));
+
+describe("public feedback", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    environment.email.user = "feedback@cityvizor.test";
+  });
+
+  it("sends requests to join with a standard sender address", async () => {
+    const sendMail = jest.fn().mockResolvedValue({ messageId: "test-message" });
+    jest.mocked(nodemailer.createTransport).mockReturnValue({
+      sendMail,
+    } as never);
+
+    const requestCityRoute = (FeedbackRouter as any).stack.find(
+      (layer: any) => layer.route?.path === "/requestcity"
+    );
+    const handler = requestCityRoute.route.stack.at(-1).handle;
+    const sendStatus = jest.fn();
+
+    await handler(
+      {
+        body: {
+          city: "Testov",
+          psc: "12345",
+          email: "user@example.test",
+          name: "Test User",
+          gdpr: true,
+          subscribe: false,
+        },
+      },
+      { sendStatus }
+    );
+
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: '"Cityvizor feedback" <feedback@cityvizor.test>',
+      })
+    );
+    expect(sendStatus).toHaveBeenCalledWith(204);
+  });
+
+  it("rejects requests when the sender address is missing", async () => {
+    environment.email.user = "  ";
+
+    const requestCityRoute = (FeedbackRouter as any).stack.find(
+      (layer: any) => layer.route?.path === "/requestcity"
+    );
+    const handler = requestCityRoute.route.stack.at(-1).handle;
+
+    await expect(
+      handler(
+        {
+          body: {
+            city: "Testov",
+            psc: "12345",
+            email: "user@example.test",
+            name: "Test User",
+            gdpr: true,
+            subscribe: false,
+          },
+        },
+        { sendStatus: jest.fn() }
+      )
+    ).rejects.toThrow("EMAIL_USER is not configured");
+
+    expect(nodemailer.createTransport).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Navazuje na #694.

- Ověří EMAIL_USER před vytvořením SMTP transportu.
- Přidává regresní test pro platnou i chybějící konfiguraci.

Nedubluje samostatnou konfiguraci z #698.

Ověřeno: npm run build --if-present, npm test -- --runInBand.