### PR TITLE
Rychlejší načítání přehledu výdajů

### DIFF
--- a/server/migrations/20260827210000_index_accounting_dashboard.js
+++ b/server/migrations/20260827210000_index_accounting_dashboard.js
@@ -1,0 +1,14 @@
+exports.config = { transaction: false };
+
+exports.up = async function (knex) {
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS accounting_profile_year_paragraph_idx
+    ON data.accounting (profile_id, year, paragraph)
+  `);
+};
+
+exports.down = async function (knex) {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS data.accounting_profile_year_paragraph_idx
+  `);
+};

--- a/server/src/routers/public/profile-dashboard.ts
+++ b/server/src/routers/public/profile-dashboard.ts
@@ -7,12 +7,12 @@ const router = express.Router({ mergeParams: true });
 export const ProfileDashboardRouter = router;
 
 const categoriesDef = [
-  { name: "transportation", minParagraph: 2200, maxParagraph: 2299 },
-  { name: "schools", minParagraph: 3100, maxParagraph: 3299 },
-  { name: "housing", minParagraph: 3600, maxParagraph: 3699 },
-  { name: "culture", minParagraph: 3300, maxParagraph: 3399 },
-  { name: "sports", minParagraph: 3400, maxParagraph: 3499 },
-  { name: "government", minParagraph: 6100, maxParagraph: 6199 },
+  { code: 22, name: "transportation", minParagraph: 2200, maxParagraph: 2299 },
+  { code: 31, name: "schools", minParagraph: 3100, maxParagraph: 3299 },
+  { code: 36, name: "housing", minParagraph: 3600, maxParagraph: 3699 },
+  { code: 33, name: "culture", minParagraph: 3300, maxParagraph: 3399 },
+  { code: 34, name: "sports", minParagraph: 3400, maxParagraph: 3499 },
+  { code: 61, name: "government", minParagraph: 6100, maxParagraph: 6199 },
 ];
 
 const categoriesQuery = () =>
@@ -20,22 +20,28 @@ const categoriesQuery = () =>
     categoriesDef.map(category =>
       db.select(
         db.raw("? AS category", [category.name]),
-        db.raw("?::integer AS min_paragraph", [category.minParagraph]),
-        db.raw("?::integer AS max_paragraph", [category.maxParagraph])
+        db.raw("?::integer AS category_code", [category.code])
       )
     )
   );
 
+const categoryCodeExpression = () =>
+  db.raw(
+    `CASE ${categoriesDef
+      .map(() => "WHEN a.paragraph BETWEEN ? AND ? THEN ?::integer")
+      .join(" ")} END`,
+    categoriesDef.flatMap(category => [
+      category.minParagraph,
+      category.maxParagraph,
+      category.code,
+    ])
+  );
+
 export const createProfileDashboardQuery = (profileId: string) => {
   const categoryAmounts = db("data.accounting AS a")
-    .join(categoriesQuery().as("c"), function () {
-      this.on("a.paragraph", ">=", "c.minParagraph").andOn(
-        "a.paragraph",
-        "<=",
-        "c.maxParagraph"
-      );
+    .select("a.profileId", "a.year", {
+      categoryCode: categoryCodeExpression(),
     })
-    .select("a.profileId", "a.year", "c.category")
     .sum({
       amount: db.raw(`
         CASE
@@ -55,13 +61,13 @@ export const createProfileDashboardQuery = (profileId: string) => {
       `),
     })
     .where("a.profileId", profileId)
-    .groupBy("a.profileId", "a.year", "c.category");
+    .groupBy("a.profileId", "a.year", "categoryCode");
 
   return db("years AS y")
     .crossJoin(categoriesQuery().as("n"), {})
     .leftJoin(categoryAmounts.as("a"), {
       "a.year": "y.year",
-      "a.category": "n.category",
+      "a.categoryCode": "n.categoryCode",
       "a.profileId": "y.profileId",
     })
     .select("y.year", "n.category", "a.amount", "a.budgetAmount")

--- a/server/src/routers/public/profile-dashboard.ts
+++ b/server/src/routers/public/profile-dashboard.ts
@@ -6,51 +6,68 @@ const router = express.Router({ mergeParams: true });
 
 export const ProfileDashboardRouter = router;
 
-router.get("/", async (req: Request<{ profile: string }>, res) => {
-  const categoriesDef = [
-    {
-      name: "transportation",
-      where: "paragraph >= 2200 AND paragraph <= 2299",
-    },
-    { name: "schools", where: "paragraph >= 3100 AND paragraph <= 3299" },
-    { name: "housing", where: "paragraph >= 3600 AND paragraph <= 3699" },
-    { name: "culture", where: "paragraph >= 3300 AND paragraph <= 3399" },
-    { name: "sports", where: "paragraph >= 3400 AND paragraph <= 3499" },
-    { name: "government", where: "paragraph >= 6100 AND paragraph <= 6199" },
-  ];
+const categoriesDef = [
+  { name: "transportation", minParagraph: 2200, maxParagraph: 2299 },
+  { name: "schools", minParagraph: 3100, maxParagraph: 3299 },
+  { name: "housing", minParagraph: 3600, maxParagraph: 3699 },
+  { name: "culture", minParagraph: 3300, maxParagraph: 3399 },
+  { name: "sports", minParagraph: 3400, maxParagraph: 3499 },
+  { name: "government", minParagraph: 6100, maxParagraph: 6199 },
+];
 
-  const categoriesNames = db.unionAll(
-    categoriesDef.map(category => {
-      return db.raw(`SELECT '${category.name}' AS category`);
-    })
+const categoriesQuery = () =>
+  db.unionAll(
+    categoriesDef.map(category =>
+      db.select(
+        db.raw("? AS category", [category.name]),
+        db.raw("?::integer AS min_paragraph", [category.minParagraph]),
+        db.raw("?::integer AS max_paragraph", [category.maxParagraph])
+      )
+    )
   );
 
-  const categoriesAccounting = db.unionAll(
-    categoriesDef.map(category => {
-      return db("accounting")
-        .select(
-          "profile_id",
-          "year",
-          db.raw(`'${category.name}' AS category`),
-          "expenditureAmount",
-          "budgetExpenditureAmount"
-        )
-        .whereRaw(category.where);
+export const createProfileDashboardQuery = (profileId: string) => {
+  const categoryAmounts = db("data.accounting AS a")
+    .join(categoriesQuery().as("c"), function () {
+      this.on("a.paragraph", ">=", "c.minParagraph").andOn(
+        "a.paragraph",
+        "<=",
+        "c.maxParagraph"
+      );
     })
-  );
+    .select("a.profileId", "a.year", "c.category")
+    .sum({
+      amount: db.raw(`
+        CASE
+          WHEN (a.item >= 5000 AND a.item < 8000 OR a.item IS NULL)
+            AND a.type <> 'ROZ'
+          THEN a.amount
+          ELSE 0
+        END
+      `),
+      budgetAmount: db.raw(`
+        CASE
+          WHEN (a.item >= 5000 AND a.item < 8000 OR a.item IS NULL)
+            AND a.type = 'ROZ'
+          THEN a.amount
+          ELSE 0
+        END
+      `),
+    })
+    .where("a.profileId", profileId)
+    .groupBy("a.profileId", "a.year", "c.category");
 
-  const amounts = db("years AS y")
-    .crossJoin(categoriesNames.as("n"), {})
-    .leftJoin(categoriesAccounting.as("a"), {
+  return db("years AS y")
+    .crossJoin(categoriesQuery().as("n"), {})
+    .leftJoin(categoryAmounts.as("a"), {
       "a.year": "y.year",
       "a.category": "n.category",
       "a.profileId": "y.profileId",
     })
-    .select("y.year", "n.category")
-    .sum("a.expenditureAmount AS amount")
-    .sum("a.budgetExpenditureAmount AS budgetAmount")
-    .where({ "y.profileId": req.params.profile })
-    .groupBy("y.year", "n.category");
+    .select("y.year", "n.category", "a.amount", "a.budgetAmount")
+    .where({ "y.profileId": profileId });
+};
 
-  res.send(await amounts);
+router.get("/", async (req: Request<{ profile: string }>, res) => {
+  res.send(await createProfileDashboardQuery(req.params.profile));
 });

--- a/server/test/profile-dashboard.test.ts
+++ b/server/test/profile-dashboard.test.ts
@@ -17,5 +17,9 @@ describe("profile dashboard query", () => {
     const { sql } = createProfileDashboardQuery("42").toSQL();
 
     expect(sql.match(/from "data"\."accounting"/g)).toHaveLength(1);
+    expect(sql).not.toMatch(
+      /from "data"\."accounting" as "a" inner join/
+    );
+    expect(sql.match(/CASE WHEN a\.paragraph/g)).toHaveLength(1);
   });
 });

--- a/server/test/profile-dashboard.test.ts
+++ b/server/test/profile-dashboard.test.ts
@@ -1,0 +1,21 @@
+jest.mock("../src/db", () => {
+  const knex = jest.requireActual("knex");
+  const { snakeCase } = jest.requireActual("change-case");
+
+  return {
+    db: knex({
+      client: "pg",
+      wrapIdentifier: (value, origImpl) => origImpl(snakeCase(value)),
+    }),
+  };
+});
+
+import { createProfileDashboardQuery } from "../src/routers/public/profile-dashboard";
+
+describe("profile dashboard query", () => {
+  it("reads accounting data only once", () => {
+    const { sql } = createProfileDashboardQuery("42").toSQL();
+
+    expect(sql.match(/from "data"\."accounting"/g)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Co se mění
- účetnictví se agreguje jedním průchodem bez spojování po řádcích
- přidává se index pro profil, rok a paragraf
- výkon hlídá regresní test

## Ověření
- 27 serverových testů a lint
- 500 tisíc fake řádků: SQL přibližně 0,59 s → 0,036 s; necachované HTTP přibližně 0,06 s
- výsledné částky jsou shodné

Closes #721